### PR TITLE
Check date time format by field first

### DIFF
--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -186,7 +186,16 @@ func (s Strategy) GetMap() Map {
 }
 
 // GetDateTimeFormat returns the datetime format for this strategy
-func (s Strategy) GetDateTimeFormat() string {
+func (s Strategy) GetDateTimeFormat(table string, field string) string {
+
+	for _, f := range s.Map.Tables[table].Fields {
+		if f["local"] == field {
+			val, exists := f["datetimeformat"]
+			if exists {
+				return val
+			}
+		}
+	}
 	return s.Map.DateTimeFormat
 }
 

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -51,10 +51,11 @@ func fakeStrategy() Strategy {
 		"type":     "int",
 	}
 	cfields[5] = map[string]string{
-		"foreign":  "createdate",
-		"local":    "DateCreated",
-		"relation": "Parse",
-		"type":     "timedate",
+		"foreign":        "createdate",
+		"local":          "DateCreated",
+		"relation":       "Parse",
+		"type":           "timedate",
+		"datetimeformat": "February 1st, 2006",
 	}
 	cfields[6] = map[string]string{
 		"foreign":  "updatedate",
@@ -238,12 +239,24 @@ func TestGetPillarEndpoints(t *testing.T) {
 func TestGetDatetimeFormat(t *testing.T) {
 	fakeConf := fakeStrategy()
 
+	table := "Comment"
+
+	// It should get the format for the strategy
+	field := "DateUpdated"
 	expectedDTformat := "2006-01-02 15:04:05"
-	dtformat := fakeConf.GetDateTimeFormat() //table, field)
+	dtformat := fakeConf.GetDateTimeFormat(table, field)
 
 	if dtformat != expectedDTformat {
 		t.Errorf("Expected %s, got %s", expectedDTformat, dtformat)
 	}
 
-	//
+	// // It should get the format for the field
+	field = "DateCreated"
+	expectedDTformat = "February 1st, 2006"
+	dtformat = fakeConf.GetDateTimeFormat(table, field)
+
+	if dtformat != expectedDTformat {
+		t.Errorf("Expected %s, got %s", expectedDTformat, dtformat)
+	}
+
 }


### PR DESCRIPTION
Issue #15. 

Now we optional have  a new key "datetimeformat" in each field . If that key exists then it gets the datetime format from there. Otherwise it goes with the configuration for the whole strategy.