### PR TITLE
Fix GetDateTimeFormat bug

### DIFF
--- a/pkg/fiddler/fiddler.go
+++ b/pkg/fiddler/fiddler.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	strategy = str.New() // Reads the strategy file
-	dateLayout = strategy.GetDateTimeFormat()
+	dateLayout = strategy.GetDefaultDateTimeFormat()
 }
 
 // GetID returns the identifier for modelName

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -185,6 +185,10 @@ func (s Strategy) GetMap() Map {
 	return s.Map
 }
 
+func (s Strategy) GetDefaultDateTimeFormat() string {
+	return s.Map.DateTimeFormat
+}
+
 // GetDateTimeFormat returns the datetime format for this strategy
 func (s Strategy) GetDateTimeFormat(table string, field string) string {
 
@@ -196,7 +200,7 @@ func (s Strategy) GetDateTimeFormat(table string, field string) string {
 			}
 		}
 	}
-	return s.Map.DateTimeFormat
+	return s.GetDefaultDateTimeFormat()
 }
 
 // GetTables returns a list of tables to be imported


### PR DESCRIPTION
Refactored the GetDateTimeFormat func into a get default and global get to allow for the default to be used independently of any configuration.  Fixes runtime error.