### PR TITLE
Flag to choose where to write the errors to

### DIFF
--- a/app/sponge/main.go
+++ b/app/sponge/main.go
@@ -41,7 +41,7 @@ func init() {
 	logLevel := func() int {
 		ll, err := cfg.Int("LOGGING_LEVEL")
 		if err != nil {
-			return log.DEV
+			return log.USER
 		}
 		return ll
 	}

--- a/app/sponge/main.go
+++ b/app/sponge/main.go
@@ -22,7 +22,8 @@ var (
 	orderbyFlag string
 
 	// Import from report on failed records (or not)
-	importonlyfailedFlag bool
+	importonlyfailedFlag string
+	errorsfileFlag       string
 
 	tableFlag string
 )
@@ -31,7 +32,8 @@ const (
 	limitDefault            = 9999999999
 	offsetDefault           = 0
 	orderbyDefault          = ""
-	importonlyfailedDefault = false
+	importonlyfailedDefault = ""
+	errorsfileDefault       = "failed_import.csv"
 	tableDefault            = ""
 )
 
@@ -51,8 +53,9 @@ func init() {
 	flag.IntVar(&limitFlag, "limit", limitDefault, "-limit= Number of rows that we are going to import at a time")
 	flag.IntVar(&offsetFlag, "offset", offsetDefault, "-offset= Offset for the sql query")
 	flag.StringVar(&orderbyFlag, "orderby", orderbyDefault, "-orderby= Order by field of the query on external source")
-	flag.BoolVar(&importonlyfailedFlag, "onlyfails", importonlyfailedDefault, "-onlyfails Import only the failed documents recorded in report")
-	flag.StringVar(&tableFlag, "type", tableDefault, "Import only that type of data.")
+	flag.StringVar(&importonlyfailedFlag, "onlyfails", importonlyfailedDefault, "-onlyfails Import only the failed documents recorded in report")
+	flag.StringVar(&errorsfileFlag, "errors", errorsfileDefault, "-errors Set the path to the file path where to record errors to")
+	flag.StringVar(&tableFlag, "type", tableDefault, "-type Import only that type of data.")
 
 	flag.Parse()
 
@@ -61,7 +64,7 @@ func init() {
 func main() {
 	log.Dev("cmd", "main", "Start")
 
-	sponge.Import(limitFlag, offsetFlag, orderbyFlag, tableFlag, importonlyfailedFlag)
+	sponge.Import(limitFlag, offsetFlag, orderbyFlag, tableFlag, importonlyfailedFlag, errorsfileFlag)
 
 	log.Dev("cmd", "main", "Complete")
 }

--- a/pkg/coral/coral.go
+++ b/pkg/coral/coral.go
@@ -73,6 +73,8 @@ func doRequest(method string, urlStr string, payload io.Reader) error {
 	client := &http.Client{}
 	var response *http.Response
 
+	// only retry if there is a network Errorf
+
 	// Retry retryTimes times if it fails to do the request
 	for i := 0; i < retryTimes; i++ {
 		response, err = client.Do(request)
@@ -81,15 +83,13 @@ func doRequest(method string, urlStr string, payload io.Reader) error {
 		} else {
 			if response.StatusCode != 200 {
 				err = fmt.Errorf("Not succesful status code: %s.", response.Status)
-				log.Error("coral", "doRequest", err, "Processing request")
+				// wait and retry to do the request
+				time.Sleep(250 * time.Millisecond)
 			} else {
 				defer response.Body.Close()
 				break
 			}
 		}
-
-		// wait and retry to do the request
-		time.Sleep(250 * time.Millisecond)
 	}
 	return err
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	filePath = "failed_import.csv"
+	filePathDefault = "failed_import.csv"
 )
 
 var records [][]string
@@ -58,9 +58,9 @@ func GetRecords() [][]string {
 }
 
 // Write writes the report to disk
-func Write() {
+func Write(filePath string) {
 	// remove existing file
-	os.Remove(filePath)
+	//os.Remove(filePath)
 
 	// only write the file if there is any report to write
 	if len(records) > 1 {
@@ -93,7 +93,7 @@ func Write() {
 //* This functions are for the old report that is already save in disk. *//
 
 // ReadReport gets the data that needs to be imported from the report already in disk and return the records in a way that can be easily read it
-func ReadReport() ([]map[string]interface{}, error) {
+func ReadReport(filePath string) ([]map[string]interface{}, error) {
 	// Read the CSV file
 	outfile, err := os.Open(filePath)
 	if err != nil {

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -56,6 +56,7 @@ func TestRecord(t *testing.T) {
 //func Write() {
 func TestWrite(t *testing.T) {
 
+	filePath := "failed_import.csv"
 	model := "comment"
 	id := "1"
 	row := map[string]interface{}{"id": "1", "body": "comment"}
@@ -64,10 +65,9 @@ func TestWrite(t *testing.T) {
 
 	Record(model, id, row, note, e)
 
-	Write()
+	Write(filePath)
 
 	// test the file was written
-	filePath := "failed_import.csv"
 	outfile, err := os.Open(filePath)
 	if err != nil {
 		t.Fatalf("unable to open file %s.", filePath)
@@ -89,6 +89,7 @@ func TestWrite(t *testing.T) {
 
 func TestReadReport(t *testing.T) {
 
+	filePath := "failed_import.csv"
 	model := "comment"
 	id := "1"
 	row := map[string]interface{}{"id": "1", "body": "comment"}
@@ -97,9 +98,9 @@ func TestReadReport(t *testing.T) {
 
 	Record(model, id, row, note, e)
 
-	Write()
+	Write(filePath)
 
-	records, err := ReadReport()
+	records, err := ReadReport(filePath)
 	if err != nil {
 		t.Fatalf("got an error when reading report")
 	}

--- a/pkg/sponge/sponge.go
+++ b/pkg/sponge/sponge.go
@@ -12,12 +12,12 @@ import (
 )
 
 // Import gets data, transform it and send it to pillar
-func Import(limit int, offset int, orderby string, table string, importonlyfailed bool) {
+func Import(limit int, offset int, orderby string, table string, importonlyfailed string, errorsfile string) {
 
 	// Initialize the report and write it down at the end (it does not create the file until the end)
 	report.Init()
 
-	defer report.Write()
+	defer report.Write(errorsfile)
 
 	// Connect to external source
 	log.User("main", "import", "### Connecting to external database...")
@@ -27,8 +27,8 @@ func Import(limit int, offset int, orderby string, table string, importonlyfaile
 		log.Error("sponge", "import", err, "Connect to external MySQL")
 	}
 
-	if importonlyfailed { // import only what is in the report of failed importeda
-		importOnlyFailedRecords(mysql, limit, offset, orderby)
+	if importonlyfailed != "" { // import only what is in the report of failed importeda
+		importOnlyFailedRecords(mysql, limit, offset, orderby, importonlyfailed)
 	} else { // import everything that is in the strategy
 		if table != "" {
 			importTable(mysql, limit, offset, orderby, table)
@@ -40,12 +40,12 @@ func Import(limit int, offset int, orderby string, table string, importonlyfaile
 }
 
 // Import gets data from report on failed import, transform it and send it to pillar
-func importOnlyFailedRecords(mysql source.Sourcer, limit int, offset int, orderby string) {
+func importOnlyFailedRecords(mysql source.Sourcer, limit int, offset int, orderby string, importonlyfailed string) {
 
 	log.User("sponge", "importOnlyFailedRecords", "### Reading file of data to import.")
 
 	// get the data that needs to be imported
-	rowsToImport, err := report.ReadReport() //[]map[string]interface{}
+	rowsToImport, err := report.ReadReport(importonlyfailed) //[]map[string]interface{}
 	if err != nil {
 		log.Error("sponge", "importOnlyFailedRecords", err, "Getting the rows that will be imported")
 	}

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -17,7 +17,7 @@ func init() {
 	logLevel := func() int {
 		ll, err := cfg.Int("LOGGING_LEVEL")
 		if err != nil {
-			return log.DEV
+			return log.USER
 		}
 		return ll
 	}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1,0 +1,1 @@
+// Test that all the fields that appear in strategy are sent to pillar


### PR DESCRIPTION
This PR adds a flag for choosing an error file to log into. It saves a CSV file with all the errors that later can be used to import data from. 