### PR TITLE
Add Constant relationship to fiddler.

### DIFF
--- a/pkg/fiddler/fiddler.go
+++ b/pkg/fiddler/fiddler.go
@@ -7,6 +7,7 @@ package fiddler
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,7 +47,10 @@ func GetCollections() []string {
 }
 
 // TransformRow transform a row of data into the coral schema
-func TransformRow(row map[string]interface{}, modelName string) (interface{}, map[string]interface{}, error) { // id row, transformation, error
+func TransformRow(row map[string]interface{}, modelName string) (interface{}, []map[string]interface{}, error) { // id row, transformation, error
+
+	var newRows []map[string]interface{}
+	var err error
 
 	table := strategy.GetTables()[modelName]
 	idField := GetID(modelName)
@@ -56,18 +60,26 @@ func TransformRow(row map[string]interface{}, modelName string) (interface{}, ma
 		return "", nil, fmt.Errorf("No table %s found in the strategy file.", table)
 	}
 
-	newRow, err := transformRow(modelName, row, table.Fields)
-	if err != nil {
-		log.Error(uuid, "fiddler.transformRow", err, "Transform the row into coral.")
-		return id, nil, err
+	// if has an array field type array
+	if strategy.HasArrayField(table) {
+		newRows, err = transformRowWithArrayField(modelName, row, table.Fields)
+		if err != nil {
+			log.Error(uuid, "fiddler.transformRow", err, "Transform the row into several coral documents.")
+		}
+	} else {
+		newRow, err := transformRow(modelName, row, table.Fields)
+		if err != nil {
+			log.Error(uuid, "fiddler.transformRow", err, "Transform the row into coral.")
+			return id, nil, err
+		}
+		newRows = append(newRows, newRow)
 	}
 
-	return id, newRow, err
+	return id, newRows, err
 }
 
 // Convert a row into the comment coral structure
-
-func transformRow(modelName string, row map[string]interface{}, fields []map[string]string) (map[string]interface{}, error) {
+func transformRow(modelName string, row map[string]interface{}, fields []map[string]interface{}) (map[string]interface{}, error) {
 
 	var err error
 	// newRow will hold the transformed row
@@ -81,33 +93,175 @@ func transformRow(modelName string, row map[string]interface{}, fields []map[str
 	// Loop on the fields for the transformation
 	for _, f := range fields {
 
-		dateLayout = strategy.GetDateTimeFormat(modelName, f["local"])
+		dateLayout = strategy.GetDateTimeFormat(modelName, f["local"].(string))
 
 		// convert field f["foreign"] with value row[f["foreign"]] into field f["local"], whose relationship is f["relation"]
-		newValue, err := transformField(row[strings.ToLower(f["foreign"])], f["relation"], f["local"])
+		newValue, err := transformField(row[strings.ToLower(f["foreign"].(string))], f["relation"].(string), f["local"].(string))
 		if err != nil {
-			log.Error(uuid, "fiddler.transformRow", err, "Transforming field %s.", f["foreign"])
+			log.Error(uuid, "fiddler.transformRow", err, "Transforming field %v.", f["foreign"])
 		}
 
 		switch f["relation"] {
-		case "Source":
-			// {
-			//	"source":
-			//					{ "asset_id": xxx},
-			// }
-			source[f["local"]] = newValue
-		case "Constant": // the value is a constant
-			newRow[f["local"]] = f["foreign"]
-		default:
-			newRow[f["local"]] = newValue
+		case "Source": // { 	"source": { "asset_id": xxx}, }
+			source[f["local"].(string)] = newValue
+
+		default: // Identity
+			newRow[f["local"].(string)] = newValue
+		}
+
+		if source != nil && len(source) > 0 {
+			newRow["source"] = source
+		}
+	}
+	return newRow, err
+}
+
+// when we are calling this func we are sure that the strategy has a field with an array
+func transformRowWithArrayField(modelName string, row map[string]interface{}, fields []map[string]interface{}) ([]map[string]interface{}, error) {
+	var err error
+	var newRows []map[string]interface{}
+
+	// newRow will hold the transformed row
+	var newRow map[string]interface{}
+	newRow = make(map[string]interface{})
+
+	// source is being used only for the special ocation when the fields relatsionship is source
+	var source map[string]interface{}
+	source = make(map[string]interface{})
+
+	// Loop on the fields for the transformation
+	for _, f := range fields {
+		foreign := f["foreign"].(string)
+		relation := f["relation"].(string)
+
+		switch f["relation"] {
+		case "Loop":
+			newRows = transformArrayFields(foreign, f["fields"], row)
+		case "Source": // { 	"source": { "asset_id": xxx}, }
+			local := f["local"].(string)
+			// convert field f["foreign"] with value row[f["foreign"]] into field f["local"], whose relationship is f["relation"]
+			newValue, err := transformField(row[strings.ToLower(foreign)], relation, local)
+			if err != nil {
+				log.Error(uuid, "fiddler.transformRow", err, "Transforming field %s.", f["foreign"])
+			}
+			source[local] = newValue
+
+		case "Constant":
+			local := f["local"].(string)
+			newRow[local] = f["value"]
+
+		default: // Identity or ParseTimeDate
+			local := f["local"].(string)
+			dateLayout = strategy.GetDateTimeFormat(modelName, local)
+
+			// convert field f["foreign"] with value row[f["foreign"]] into field f["local"], whose relationship is f["relation"]
+			newValue, err := transformField(row[strings.ToLower(foreign)], relation, local)
+			if err != nil {
+				log.Error(uuid, "fiddler.transformRow", err, "Transforming field %s.", f["foreign"])
+			}
+			newRow[local] = newValue
+		}
+
+		if source != nil && len(source) > 0 {
+			newRow["source"] = source
+		}
+	}
+	// add newRow to all rows in newRows
+	for i := range newRows {
+
+		for key := range newRow {
+			//fmt.Printf("Adding value %v for key %v. \n\n", newRow[key], key)
+			if key == "source" {
+				for k := range newRow[key].(map[string]interface{}) {
+					newRows[i][key].(map[string]interface{})[k] = newRow[key].(map[string]interface{})[k]
+				}
+			} else {
+				newRows[i][key] = newRow[key]
+			}
 		}
 	}
 
-	if source != nil && len(source) > 0 {
-		newRow["source"] = source
-	}
+	return newRows, err
+}
 
-	return newRow, err
+// "fields": [
+// 	{
+// 		"foreign": "published",
+// 		"local": "date",
+// 		"relation": "Identity"
+// 	},
+// 	{
+// 		"foreign": "actor.id",
+// 		"local" : "userid",
+// 		"relation": "Source"
+// 	}
+// ],
+
+//
+// "object" : {
+// 	"likes" : [
+// 		{
+// 			"actor" : {
+// 				...}
+// 			}
+// 			]
+// 		}
+//
+// row[object.likes.i.published , objects.likes.i.actor.id]
+//
+// object.likes.0.actor.
+// object.likes.1.actor.
+// object.likes.2.actor.
+
+func transformArrayFields(foreign string, fields interface{}, row map[string]interface{}) []map[string]interface{} {
+	var newRows []map[string]interface{}
+	// The transformation for one row with arrays is multiple rows
+
+	// We are getting each row into newRow
+	newRow := make(map[string]interface{})
+	source := make(map[string]interface{})
+
+	// While still have more rows to add
+	finish := false
+	i := 0
+	for !finish {
+		for _, f := range fields.([]interface{}) { // loop through all the fields that we need to create the row
+
+			field := f.(map[string]interface{})
+			lastfield := field["foreign"].(string)
+
+			fi := foreign + "." + strconv.Itoa(i) + "." + lastfield // this one is the field in the source document
+
+			// if that row has data on fi
+			if row[fi] != nil {
+				// transform that specific field
+				newvalue, err := transformField(row[fi], field["relation"].(string), field["local"].(string))
+				if err != nil {
+					log.Error(uuid, "fiddler.transformRow", err, "Transforming field %s.", field["foreign"])
+				}
+				switch field["relation"] {
+				case "Source":
+					source[field["local"].(string)] = newvalue
+				default:
+					newRow[field["local"].(string)] = newvalue
+				}
+				if source != nil && len(source) > 0 {
+					newRow["source"] = source
+				}
+			} else {
+				finish = true //I'm assuming that we are done when one of the fields.i.whatever has not data
+				break
+			}
+		}
+		if len(newRow) > 0 { // Add the row only if we got any
+			newRows = append(newRows, newRow)
+			newRow = make(map[string]interface{}) // initialize the row to get the next one
+			source = make(map[string]interface{})
+		}
+
+		i++ // NEXT POSSIBLE ROW
+	}
+	return newRows
 }
 
 //Here we transform the record into what we want (based on the configuration in the strategy)
@@ -133,8 +287,8 @@ func transformField(oldValue interface{}, relation string, local string) (interf
 				return "", fmt.Errorf("Type of data %v not recognizable.", v)
 			}
 		}
-		err = fmt.Errorf("Type of transformation %s not found for %v.", relation, oldValue)
 	}
+	err = fmt.Errorf("Type of transformation %s not found for %v.", relation, oldValue)
 
 	return tfield, err
 }

--- a/pkg/fiddler/fiddler.go
+++ b/pkg/fiddler/fiddler.go
@@ -89,17 +89,17 @@ func transformRow(modelName string, row map[string]interface{}, fields []map[str
 			log.Error(uuid, "fiddler.transformRow", err, "Transforming field %s.", f["foreign"])
 		}
 
-		if newValue != nil {
-
-			if f["relation"] != "Source" {
-				newRow[f["local"]] = newValue // newvalue could be string or time.Time or int
-			} else { // special case when I'm looking into a source relationship
-				// {
-				//	"source":
-				//					{ "asset_id": xxx},
-				// }
-				source[f["local"]] = newValue
-			}
+		switch f["relation"] {
+		case "Source":
+			// {
+			//	"source":
+			//					{ "asset_id": xxx},
+			// }
+			source[f["local"]] = newValue
+		case "Constant": // the value is a constant
+			newRow[f["local"]] = f["foreign"]
+		default:
+			newRow[f["local"]] = newValue
 		}
 	}
 

--- a/pkg/fiddler/fiddler_test.go
+++ b/pkg/fiddler/fiddler_test.go
@@ -62,28 +62,30 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// Signature: TransformRow(row map[string]interface{}, modelName string) ([]byte, error)
+// Signature: TransformRow(row map[string]interface{}, modelName string) (interface{}, []map[string]interface{}, error) { // id row, transformation, error
 func TestTransformRow(t *testing.T) {
 	row := map[string]interface{}{"assetid": "3416344", "asseturl": "http://www.nytimes.com/interactive/2014/11/24/us/north-dakota-oil-boom-politics.html", "updatedate": "2014-12-04 00:01:11", "createdate": "2014-12-04 00:01:11"}
-	modelName := "asset"
+	modelName := "assets"
 
+	// interface{}, []map[string]interface{}, error)
 	id, result, err := TransformRow(row, modelName)
 	if err != nil {
 		t.Fatalf("error should be nil. Error is %v", err)
 	}
 
-	expectedResult := map[string]interface{}{"date_updated": "2014-12-04T00:01:11Z", "date_created": "2014-12-04T00:01:11Z", "source": map[string]string{"id": "3416344"}, "url": "http://www.nytimes.com/interactive/2014/11/24/us/north-dakota-oil-boom-politics.html"}
+	expectedResult := make([]map[string]interface{}, 1)
+	expectedResult[0] = map[string]interface{}{"date_updated": "2014-12-04T00:01:11Z", "date_created": "2014-12-04T00:01:11Z", "source": map[string]string{"id": "3416344"}, "url": "http://www.nytimes.com/interactive/2014/11/24/us/north-dakota-oil-boom-politics.html"}
 
 	if len(result) != len(expectedResult) {
 		t.Fatalf("got %d , expected %d", len(result), len(expectedResult))
 	}
 
-	if result["date_updated"] != expectedResult["date_updated"] {
-		t.Fatalf("got %s , expected %s", result["date_updated"], expectedResult["date_updated"])
+	if result[0]["date_updated"] != expectedResult[0]["date_updated"] {
+		t.Fatalf("got %s , expected %s", result[0]["date_updated"], expectedResult[0]["date_updated"])
 	}
 
-	if result["url"] != expectedResult["url"] {
-		t.Fatalf("got %s , expected %s", result["url"], expectedResult["url"])
+	if result[0]["url"] != expectedResult[0]["url"] {
+		t.Fatalf("got %s , expected %s", result[0]["url"], expectedResult[0]["url"])
 	}
 
 	expectedID := "3416344"
@@ -92,8 +94,157 @@ func TestTransformRow(t *testing.T) {
 	}
 }
 
+// Test array documents
+// Signature: TransformRow(row map[string]interface{}, modelName string) (interface{}, []map[string]interface{}, error) { // id row, transformation, error
+func TestTransformRowArrayTypesNotDuplicating(t *testing.T) {
+
+	row := map[string]interface{}{
+		"provider.icon": "http://cdn.echoenabled.com/images/echo.png", "object.accumulators.likesCount": 1,
+		"object.status": "Untouched", "actor.avatar": "https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png",
+		"object.permalink": "",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.avatar:https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png": "",
+		"actor._id": "http://washingtonpost.com/yH5FvK5Hcr6lmQeD6Xcx8fJkV59ZvvsMzHeNJ1Se1fpoGeVxxhJF5A%3D%3D/",
+		"actor.id":  "http://washingtonpost.com/yH5FvK5Hcr6lmQeD6Xcx8fJkV59ZvvsMzHeNJ1Se1fpoGeVxxhJF5A%3D%3D/",
+		"targets": []map[string]string{
+			map[string]string{"conversationID": "http://washingtonpost.com/ECHO/item/2d1d3956-08a4-4aaa-9ffd-22182fbb5b8f",
+				"id": "http://washingtonpost.com/ECHO/item/2d1d3956-08a4-4aaa-9ffd-22182fbb5b8f"},
+		},
+		"object.tags.0":        "replyto_Tropicat",
+		"object.content":       "Probably nothing since otherwise these folks would just have been sitting around the hotel waiting for meetings to start.",
+		"object.context.0.uri": "http://washingtonpost.com/news/to-your-health/wp/2015/05/31/no-stranger-to-brutal-sports-injuries-kerry-faces-a-long-road-to-recovery/",
+		"source.name":          "washpost.com", "provider.name": "echo", "object.likes.0.actor.title": "Yersinia_pestis",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.published:2015-06-03T16:50:15Z": "",
+		"updated": "2015-06-03 09:50:15.668 -0700 PDT", "ip": "10.128.133.132",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.title:Yersinia_pestis":                                                                        "",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.id:http://washingtonpost.com/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/": "",
+		"object.id":           "http://washingtonpost.com/ECHO/item/fc3be552-cb73-45e5-9d50-73b1b754663b",
+		"actor.objectTypes.0": "http://activitystrea.ms/schema/1.0/person",
+		"id":           "http://js-kit.com/activities/post/fc3be552-cb73-45e5-9d50-73b1b754663b",
+		"verbs":        []string{"http://activitystrea.ms/schema/1.0/post"},
+		"provider.uri": "http://aboutecho.com/", "object.content_type": "html",
+		"object.objectTypes.0": "http://activitystrea.ms/schema/1.0/comment", "actor.status": "ModeratorApproved",
+		"postedTime": "2015-05-31 17:00:12.683 -0700 PDT", "_id": "ObjectIdHex(\"556ba08cd710290035cf6c74\")",
+		"object.published": "2015-06-01T00:00:12Z",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.objectTypes.0:http://activitystrea.ms/schema/1.0/person": "",
+		"object.context.0.title": "", "actor.title": "Zeus Mom",
+		"object.likes.0.actor.id":            "http://washingtonpost.com/user0/",
+		"object.likes.0.actor.avatar":        "https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png",
+		"object.likes.0.actor.objectTypes.0": "http://activitystrea.ms/schema/1.0/person",
+		"object.likes.0.published":           "2015-06-03T16:50:15Z",
+	}
+	modelName := "actions"
+
+	// interface{}, []map[string]interface{}, error)
+	id, result, err := TransformRow(row, modelName)
+	if err != nil {
+		t.Fatalf("error should be nil. Error is %v", err)
+	}
+
+	expectedResult := make([]map[string]interface{}, 1)
+	expectedResult[0] = map[string]interface{}{
+		"type": "likes", "target": "comments",
+		"date": "2015-06-03T16:50:15Z",
+		"source": map[string]interface{}{
+			"user_id":   "http://washingtonpost.com/user0/",
+			"target_id": "ObjectIdHex(\"556ba08cd710290035cf6c74\")",
+		},
+	}
+
+	if len(result) != len(expectedResult) {
+		t.Fatalf("got %d , expected %d", len(result), len(expectedResult))
+	}
+
+	expectedID := "ObjectIdHex(\"556ba08cd710290035cf6c74\")"
+	if id != expectedID {
+		t.Fatalf("got %s, expected %s", id, expectedID)
+	}
+}
+
+// Test array documents
+// Signature: TransformRow(row map[string]interface{}, modelName string) (interface{}, []map[string]interface{}, error) { // id row, transformation, error
+func TestTransformRowArrayTypes(t *testing.T) {
+
+	row := map[string]interface{}{
+		"provider.icon": "http://cdn.echoenabled.com/images/echo.png", "object.accumulators.likesCount": 1,
+		"object.status": "Untouched", "actor.avatar": "https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png",
+		"object.permalink": "",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.avatar:https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png": "",
+		"actor._id": "http://washingtonpost.com/yH5FvK5Hcr6lmQeD6Xcx8fJkV59ZvvsMzHeNJ1Se1fpoGeVxxhJF5A%3D%3D/",
+		"actor.id":  "http://washingtonpost.com/yH5FvK5Hcr6lmQeD6Xcx8fJkV59ZvvsMzHeNJ1Se1fpoGeVxxhJF5A%3D%3D/",
+		"targets": []map[string]string{
+			map[string]string{"conversationID": "http://washingtonpost.com/ECHO/item/2d1d3956-08a4-4aaa-9ffd-22182fbb5b8f",
+				"id": "http://washingtonpost.com/ECHO/item/2d1d3956-08a4-4aaa-9ffd-22182fbb5b8f"},
+		},
+		"object.tags.0":        "replyto_Tropicat",
+		"object.content":       "Probably nothing since otherwise these folks would just have been sitting around the hotel waiting for meetings to start.",
+		"object.context.0.uri": "http://washingtonpost.com/news/to-your-health/wp/2015/05/31/no-stranger-to-brutal-sports-injuries-kerry-faces-a-long-road-to-recovery/",
+		"source.name":          "washpost.com", "provider.name": "echo", "object.likes.0.actor.title": "Yersinia_pestis",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.published:2015-06-03T16:50:15Z": "",
+		"updated": "2015-06-03 09:50:15.668 -0700 PDT", "ip": "10.128.133.132",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.title:Yersinia_pestis":                                                                        "",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.id:http://washingtonpost.com/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/": "",
+		"object.id":           "http://washingtonpost.com/ECHO/item/fc3be552-cb73-45e5-9d50-73b1b754663b",
+		"actor.objectTypes.0": "http://activitystrea.ms/schema/1.0/person",
+		"id":           "http://js-kit.com/activities/post/fc3be552-cb73-45e5-9d50-73b1b754663b",
+		"verbs":        []string{"http://activitystrea.ms/schema/1.0/post"},
+		"provider.uri": "http://aboutecho.com/", "object.content_type": "html",
+		"object.objectTypes.0": "http://activitystrea.ms/schema/1.0/comment", "actor.status": "ModeratorApproved",
+		"postedTime": "2015-05-31 17:00:12.683 -0700 PDT", "_id": "ObjectIdHex(\"556ba08cd710290035cf6c74\")",
+		"object.published": "2015-06-01T00:00:12Z",
+		"object.likes_obj.http://washingtonpostcom/E2vgkjF8Dr3osyRlhbNLC%2BwKrkvbT4tmsKR0XWQVNYpoGeVxxhJF5A%3D%3D/.actor.objectTypes.0:http://activitystrea.ms/schema/1.0/person": "",
+		"object.context.0.title": "", "actor.title": "Zeus Mom",
+		"object.likes.0.actor.id":            "http://washingtonpost.com/user0/",
+		"object.likes.0.actor.avatar":        "https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png",
+		"object.likes.0.actor.objectTypes.0": "http://activitystrea.ms/schema/1.0/person",
+		"object.likes.0.published":           "2015-06-03T16:50:15Z",
+		"object.likes.1.actor.id":            "http://washingtonpost.com/user1/",
+		"object.likes.1.actor.avatar":        "https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png",
+		"object.likes.1.actor.objectTypes.0": "http://activitystrea.ms/schema/1.0/person",
+		"object.likes.1.published":           "2015-06-03T16:50:15Z",
+	}
+	modelName := "actions"
+
+	// interface{}, []map[string]interface{}, error)
+	id, result, err := TransformRow(row, modelName)
+	if err != nil {
+		t.Fatalf("error should be nil. Error is %v", err)
+	}
+
+	expectedResult := make([]map[string]interface{}, 2)
+	expectedResult[0] = map[string]interface{}{
+		"type": "likes", "target": "comments",
+		"date": "2015-06-03T16:50:15Z",
+		"source": map[string]interface{}{
+			"user_id":   "http://washingtonpost.com/user0/",
+			"target_id": "ObjectIdHex(\"556ba08cd710290035cf6c74\")",
+		},
+	}
+	expectedResult[1] = map[string]interface{}{
+		"type": "likes", "target": "comments",
+		"date": "2015-06-03T16:50:15Z",
+		"source": map[string]interface{}{
+			"user_id":   "http://washingtonpost.com/user1/",
+			"target_id": "ObjectIdHex(\"556ba08cd710290035cf6c74\")",
+		},
+	}
+
+	if len(result) != len(expectedResult) {
+		t.Fatalf("got %d , expected %d", len(result), len(expectedResult))
+	}
+
+	expectedID := "ObjectIdHex(\"556ba08cd710290035cf6c74\")"
+	if id != expectedID {
+		t.Fatalf("got %s, expected %s", id, expectedID)
+	}
+
+	// all the rows have different ids
+	if result[0]["source"].(map[string]interface{})["user_id"] == result[1]["source"].(map[string]interface{})["user_id"] {
+		t.Fatalf("It is duplicating documents")
+	}
+}
+
 // Test there is an error when model does not exist.
-// Signature: TransformRow(row map[string]interface{}, modelName string) ([]byte, error)
+// Signature: TransformRow(row map[string]interface{}, modelName string) (interface{}, []map[string]interface{}, error) { // id row, transformation, error
 func TestTransformRowNoModel(t *testing.T) {
 	row := map[string]interface{}{}
 	modelName := "papafrita"
@@ -110,7 +261,7 @@ func TestTransformRowNoModel(t *testing.T) {
 
 // Signature:  GetID(modelName string) string
 func TestGetID(t *testing.T) {
-	modelName := "asset"
+	modelName := "assets"
 	expectedID := "assetid"
 
 	id := GetID(modelName)
@@ -122,9 +273,10 @@ func TestGetID(t *testing.T) {
 // Signature:  GetCollections() []string {
 func TestGetCollections(t *testing.T) {
 	expectedCollections := []string{
-		"asset",
-		"user",
-		"comment",
+		"assets",
+		"users",
+		"comments",
+		"actions",
 	}
 
 	collections := GetCollections()

--- a/pkg/fiddler/fiddler_test.go
+++ b/pkg/fiddler/fiddler_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 
 // Signature: TransformRow(row map[string]interface{}, modelName string) ([]byte, error)
 func TestTransformRow(t *testing.T) {
-	row := map[string]interface{}{"assetid": "3416344", "asseturl": "http://www.nytimes.com/interactive/2014/11/24/us/north-dakota-oil-boom-politics.html", "updatedate": "2014-12-04 00:01:11"}
+	row := map[string]interface{}{"assetid": "3416344", "asseturl": "http://www.nytimes.com/interactive/2014/11/24/us/north-dakota-oil-boom-politics.html", "updatedate": "2014-12-04 00:01:11", "createdate": "2014-12-04 00:01:11"}
 	modelName := "asset"
 
 	id, result, err := TransformRow(row, modelName)
@@ -72,7 +72,7 @@ func TestTransformRow(t *testing.T) {
 		t.Fatalf("error should be nil. Error is %v", err)
 	}
 
-	expectedResult := map[string]interface{}{"date_updated": "2014-12-04T00:01:11Z", "source": map[string]string{"id": "3416344"}, "url": "http://www.nytimes.com/interactive/2014/11/24/us/north-dakota-oil-boom-politics.html"}
+	expectedResult := map[string]interface{}{"date_updated": "2014-12-04T00:01:11Z", "date_created": "2014-12-04T00:01:11Z", "source": map[string]string{"id": "3416344"}, "url": "http://www.nytimes.com/interactive/2014/11/24/us/north-dakota-oil-boom-politics.html"}
 
 	if len(result) != len(expectedResult) {
 		t.Fatalf("got %d , expected %d", len(result), len(expectedResult))

--- a/pkg/source/README.md
+++ b/pkg/source/README.md
@@ -1,0 +1,13 @@
+## How to add a new source
+
+#### Package Source
+Any new source has to be included in the package source and implement the interface Sourcer:
+
+// Sourcer is where the data is coming from (mysql, mongodb, api, postgresql, etc)
+type Sourcer interface {
+	GetData(string, int, int, string) ([]map[string]interface{}, error) //tableName, offset, limit, orderby
+	GetQueryData(string, int, int, string, []string) ([]map[string]interface{}, error)
+	GetTables() ([]string, error)
+}
+
+#### Include the source into source.New function

--- a/pkg/source/mongodb.go
+++ b/pkg/source/mongodb.go
@@ -67,7 +67,7 @@ func (m MongoDB) GetData(coralTableName string, offset int, limit int, orderby s
 	fieldsToGet := make(map[string]bool)
 	//var fieldsNames []string
 	for _, f := range fields {
-		fieldsToGet[f["foreign"]] = true
+		fieldsToGet[f["foreign"].(string)] = true
 		//fieldsNames = append(fieldsNames, f["local"])
 	}
 

--- a/pkg/source/mysql.go
+++ b/pkg/source/mysql.go
@@ -54,7 +54,7 @@ func (m MySQL) GetData(coralTableName string, offset int, limit int, orderby str
 	f := make([]string, 0, len(tableFields))
 	for _, field := range tableFields {
 		if field != nil {
-			f = append(f, field["foreign"])
+			f = append(f, field["foreign"].(string))
 		}
 	}
 
@@ -105,7 +105,7 @@ func (m MySQL) GetQueryData(coralTableName string, offset int, limit int, orderb
 	f := make([]string, 0, len(tableFields))
 	for _, field := range tableFields {
 		if field != nil {
-			f = append(f, field["foreign"])
+			f = append(f, field["foreign"].(string))
 		}
 	}
 

--- a/pkg/strategy/README.md
+++ b/pkg/strategy/README.md
@@ -110,12 +110,16 @@ The name of the field in our local database.
 
 The relationship between the foreign field and the local one. We have this options:
 - Identity: when the value is the same
-- Source: when it needs to be added to our source struct for the local table (the orignal identifiers have to go into source)
+- Source: when it needs to be added to our source struct for the local table (the original identifiers have to go into source)
 - ParseTimeDate: when we need to parse the foreign value as date time.
+- Constant: when the local field should always be the same value. In this case we will have "foreign" blank and we will have other field called "value" with the value of the local field.
 
 ###### Type
 
 The type of the value we are converting.
+
+- String
+- Timedate
 
 ## Credentials
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -55,14 +55,14 @@ type Map struct {
 
 // Table holds the struct on what is the external source's table name and fields
 type Table struct {
-	Foreign  string              `json:"foreign"`
-	Local    string              `json:"local"`
-	Priority int                 `json:"priority"`
-	OrderBy  string              `json:"orderby"`
-	ID       string              `json:"id"`
-	Index    []mgo.Index         `json:"index"`  //map[string]interface{} `json:"index"`
-	Fields   []map[string]string `json:"fields"` // foreign (name in the foreign source), local (name in the local source), relation (relationship between each other), type (data type)
-	Endpoint string              `json:"endpoint"`
+	Foreign  string                   `json:"foreign"`
+	Local    string                   `json:"local"`
+	Priority int                      `json:"priority"`
+	OrderBy  string                   `json:"orderby"`
+	ID       string                   `json:"id"`
+	Index    []mgo.Index              `json:"index"`  //map[string]interface{} `json:"index"`
+	Fields   []map[string]interface{} `json:"fields"` // foreign (name in the foreign source), local (name in the local source), relation (relationship between each other), type (data type)
+	Endpoint string                   `json:"endpoint"`
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -203,7 +203,7 @@ func (s Strategy) GetDateTimeFormat(table string, field string) string {
 		if f["local"] == field {
 			val, exists := f["datetimeformat"]
 			if exists {
-				return val
+				return val.(string)
 			}
 		}
 	}
@@ -217,13 +217,25 @@ func (s Strategy) GetTables() map[string]Table {
 	return s.Map.Tables
 }
 
+// HasArrayField returns true if the table has fields that are type array and need to be loop through
+func (s Strategy) HasArrayField(t Table) bool {
+	//Fields   []map[string]interface{}
+
+	for _, f := range t.Fields {
+		if f["type"] == "Array" {
+			return true
+		}
+	}
+	return false
+}
+
 // GetTableForeignName returns the external source's table mapped to the coral model
 func (s Strategy) GetTableForeignName(coralName string) string {
 	return s.Map.Tables[coralName].Foreign
 }
 
 // GetTableForeignFields returns the external source's table fields mapped to the coral model
-func (s Strategy) GetTableForeignFields(coralName string) []map[string]string {
+func (s Strategy) GetTableForeignFields(coralName string) []map[string]interface{} {
 	return s.Map.Tables[coralName].Fields
 }
 

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -23,86 +23,86 @@ func fakeStrategy() Strategy {
 		Type:     "source",
 	}
 
-	cfields := make([]map[string]string, 8)
+	cfields := make([]map[string]interface{}, 8)
 
-	cfields[0] = map[string]string{
+	cfields[0] = map[string]interface{}{
 		"foreign":  "commentid",
 		"local":    "CommentID",
 		"relation": "Identity",
 		"type":     "int",
 	}
-	cfields[1] = map[string]string{
+	cfields[1] = map[string]interface{}{
 		"foreign":  "commentbody",
 		"local":    "Body",
 		"relation": "Identity",
 		"type":     "[]byte",
 	}
-	cfields[2] = map[string]string{
+	cfields[2] = map[string]interface{}{
 		"foreign":  "parentid",
 		"local":    "ParentID",
 		"relation": "Identity",
 		"type":     "int",
 	}
-	cfields[3] = map[string]string{
+	cfields[3] = map[string]interface{}{
 		"foreign":  "assetid",
 		"local":    "AssetID",
 		"relation": "Identity",
 		"type":     "int",
 	}
-	cfields[4] = map[string]string{
+	cfields[4] = map[string]interface{}{
 		"foreign":  "statusid",
 		"local":    "Status",
 		"relation": "Identity",
 		"type":     "int",
 	}
-	cfields[5] = map[string]string{
+	cfields[5] = map[string]interface{}{
 		"foreign":        "createdate",
 		"local":          "DateCreated",
 		"relation":       "Parse",
 		"type":           "timedate",
 		"datetimeformat": "February 1st, 2006",
 	}
-	cfields[6] = map[string]string{
+	cfields[6] = map[string]interface{}{
 		"foreign":  "updatedate",
 		"local":    "DateUpdated",
 		"relation": "Parse",
 		"type":     "timedate",
 	}
-	cfields[7] = map[string]string{
+	cfields[7] = map[string]interface{}{
 		"foreign":  "approvedate",
 		"local":    "DateApproved",
 		"relation": "Parse",
 		"type":     "timedate",
 	}
 
-	afields := make([]map[string]string, 3)
-	afields[0] = map[string]string{
+	afields := make([]map[string]interface{}, 3)
+	afields[0] = map[string]interface{}{
 		"foreign":  "assetid",
 		"local":    "AssetID",
 		"relation": "identity",
 		"type":     "int",
 	}
-	afields[1] = map[string]string{
+	afields[1] = map[string]interface{}{
 		"foreign":  "sourceid",
 		"local":    "SourceID",
 		"relation": "identity",
 		"type":     "int",
 	}
-	afields[2] = map[string]string{
+	afields[2] = map[string]interface{}{
 		"foreign":  "asseturl",
 		"local":    "URL",
 		"relation": "identity",
 		"type":     "[]byte",
 	}
 
-	ufields := make([]map[string]string, 6)
-	ufields[0] = map[string]string{
+	ufields := make([]map[string]interface{}, 6)
+	ufields[0] = map[string]interface{}{
 		"foreign":  "userid",
 		"local":    "UserID",
 		"relation": "identity",
 		"type":     "int",
 	}
-	ufields[1] = map[string]string{
+	ufields[1] = map[string]interface{}{
 		"foreign":  "userdisplayname",
 		"local":    "UserName",
 		"relation": "identity",
@@ -223,6 +223,18 @@ func TestGetTables(t *testing.T) {
 
 	if tables["Comment"].Foreign != "crnr_comment" {
 		t.Error("Expected crnr_comment, got ", tables["Comment"])
+	}
+}
+
+// Signature func (s Strategy) HasArrayField(t Table) bool {
+func TestHasArrayField(t *testing.T) {
+	fakeConf := fakeStrategy()
+
+	var tables map[string]Table
+	tables = fakeConf.GetTables()
+
+	if fakeConf.HasArrayField(tables["Comment"]) {
+		t.Error("Expected not to have an array field.")
 	}
 }
 


### PR DESCRIPTION
Challenge 1: The WaPo data adds the concept of "Constant" relations when mapping the actions.  We have type "Flags" and "Likes" so far for the "type" field and "Comment" for the "targettype" field.

Challenge 2: Other change to fiddler that we need to implement is when the mongo collection has an array and each item in the array is a new action. I'm thinking on adding other structure to the table in the strategy to indicate that this is the case and that an array needs to be looped to get all the needed documents to import. 

Challenge 3: For the WaPo data there is no ID for the action. But as we are upserting data we need to generate an ID from the fields we have. The proposal is to have source.id to be action.Source.UserID + "-" + actionType + "-" + comment.Source.ID . In the strategy file this will be showd as "composed" attribute. For example:
            "compose": {
              "actionType": "flag",
              "fields": ["action.Source.UserID", "comment.Source.ID"]
            }