### PR TITLE
Implements pulling data from API to transform

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,5 @@
+# Troubleshooting
+
+### unsupported protocol scheme ""
+
+- Check that you are setting up all the environment variables PILLAR_URL and STRATEGY_CONF.

--- a/cmd/sponge/cmd/import.go
+++ b/cmd/sponge/cmd/import.go
@@ -57,5 +57,6 @@ func init() {
 
 func addImport(cmd *cobra.Command, args []string) {
 
-	sponge.Import(limitFlag, offsetFlag, orderbyFlag, queryFlag, typeFlag, importonlyfailedFlag, reportErrorsFlag, localErrorsDBFlag)
+	sponge.AddOptions(limitFlag, offsetFlag, orderbyFlag, queryFlag, typeFlag, importonlyfailedFlag, reportErrorsFlag, localErrorsDBFlag)
+	sponge.Import()
 }

--- a/cmd/sponge/cmd/root.go
+++ b/cmd/sponge/cmd/root.go
@@ -77,6 +77,5 @@ func addAll(cmd *cobra.Command, args []string) {
 	addCreateIndexes(cmd, args)
 	addImport(cmd, args)
 	addReadReport(cmd, args)
-	//addStrategyValidation(cmd, args)
 
 }

--- a/cmd/sponge/cmd/root.go
+++ b/cmd/sponge/cmd/root.go
@@ -77,5 +77,6 @@ func addAll(cmd *cobra.Command, args []string) {
 	addCreateIndexes(cmd, args)
 	addImport(cmd, args)
 	addReadReport(cmd, args)
+	//addStrategyValidation(cmd, args)
 
 }

--- a/cmd/sponge/main.go
+++ b/cmd/sponge/main.go
@@ -27,7 +27,7 @@ func main() {
 		}
 		return ll
 	}
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel )
 
 	// Generate UUID to use with the logs
 	uid := uuid.New()

--- a/pkg/coral/coral.go
+++ b/pkg/coral/coral.go
@@ -95,6 +95,7 @@ func Init(u string) {
 func AddRow(data map[string]interface{}, tableName string) error {
 
 	var err error
+
 	if _, ok := endpoints[tableName]; ok {
 
 		d, err := json.Marshal(data)

--- a/pkg/coral/coral.go
+++ b/pkg/coral/coral.go
@@ -77,7 +77,7 @@ func Init(u string) {
 	strategy.Init(uuid)
 	str, err = strategy.New()
 	if err != nil {
-		log.Error(uuid, "fiddler.init", err, "Reading the streategy file.")
+		log.Error(uuid, "coral.init", err, "Reading the streategy file.")
 	}
 	endpoints = str.GetPillarEndpoints()
 }
@@ -92,7 +92,9 @@ func AddRow(data map[string]interface{}, tableName string) error {
 		if err != nil {
 			log.Error(uuid, "coral.Addrow", err, "Marshalling %v.", data)
 		}
-		_, err = webservice.DoRequest(uuid, methodPost, endpoints[tableName], bytes.NewBuffer(d))
+
+		userAgent := fmt.Sprintf("Sponge Publisher %s.", str.Name)
+		_, err = webservice.DoRequest(uuid, userAgent, methodPost, endpoints[tableName], bytes.NewBuffer(d))
 		if err != nil {
 			log.Error(uuid, "coral.Addrow", err, "Sending request to PILLAR with %v.", data)
 		}
@@ -122,14 +124,6 @@ func CreateIndex(collection string) error {
 	for i := range is {
 		indexes[i] = make(map[string]interface{})
 		indexes[i]["target"] = collection
-
-		// indexes[i]["index"] = map[string]interface{}{
-		// 	"name":     is[i]["name"].(string),
-		// 	"key":      is[i]["keys"],
-		// 	"unique":   is[i]["unique"].(string),
-		// 	"dropdups": is[i]["dropdups"].(string),
-		// }
-
 		indexes[i]["index"] = is[i]
 
 		var data []byte
@@ -138,7 +132,8 @@ func CreateIndex(collection string) error {
 			log.Error(uuid, "coral.createIndex", err, "Marshal index information.")
 		}
 
-		_, err = webservice.DoRequest(uuid, methodPost, createIndexURL, bytes.NewBuffer(data))
+		userAgent := fmt.Sprintf("Sponge Publisher %s.", str.Name)
+		_, err = webservice.DoRequest(uuid, userAgent, methodPost, createIndexURL, bytes.NewBuffer(data))
 		if err != nil {
 			log.Error(uuid, "coral.createIndex", err, "Sending request to create Index to Pillar.")
 		}

--- a/pkg/coral/coral_test.go
+++ b/pkg/coral/coral_test.go
@@ -41,7 +41,7 @@ func setup() {
 		return ll
 	}
 
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel)
 
 	//MOCK STRATEGY CONF
 	strategyConf := "../../tests/strategy_test.json"

--- a/pkg/coral/coral_test.go
+++ b/pkg/coral/coral_test.go
@@ -57,15 +57,15 @@ func setup() {
 
 		// check that the row is what we want it to be
 		switch r.RequestURI {
-		case "/api/import/users": // if user, the payload should be a user kind of payload
+		case "/api/import/user": // if user, the payload should be a user kind of payload
 			// decode the user
 			user := model.User{}
 			err = json.NewDecoder(r.Body).Decode(&user)
-		case "/api/import/assets": // if asset, the payload should be an asset kind of payload
+		case "/api/import/asset": // if asset, the payload should be an asset kind of payload
 			// decode the asset
 			asset := model.Asset{}
 			err = json.NewDecoder(r.Body).Decode(&asset)
-		case "/api/import/comments": // if comment, the payload should be a comment kind of payload
+		case "/api/import/comment": // if comment, the payload should be a comment kind of payload
 			// decode the comment
 			comment := model.Comment{}
 			err = json.NewDecoder(r.Body).Decode(&comment)

--- a/pkg/fiddler/fiddler.go
+++ b/pkg/fiddler/fiddler.go
@@ -62,7 +62,7 @@ func TransformRow(row map[string]interface{}, modelName string) (interface{}, []
 	id := row[idField]
 
 	if table.Local == "" {
-		return "", nil, fmt.Errorf("No table %s found in the strategy file.", table)
+		return "", nil, fmt.Errorf("No table %v found in the strategy file.", table)
 	}
 
 	// if has an array field type array
@@ -290,18 +290,18 @@ func transformArrayFields(foreign string, fields interface{}, row map[string]int
 	for !finish {
 		fis, ok := fields.([]interface{})
 		if !ok {
-			log.Error(uuid, "transformArrayFields", fmt.Errorf("%v not expected type", fields), "Not expected interface{} type")
+			log.Error(uuid, "fiddler.transformArrayFields", fmt.Errorf("%v not expected type", fields), "Not expected interface{} type")
 		}
 
 		for _, f := range fis { // loop through all the fields that we need to create the row
 
 			field, ok := f.(map[string]interface{})
 			if !ok {
-				log.Error(uuid, "transformArrayFields", fmt.Errorf("%v not expected type", f), "Not expected type")
+				log.Error(uuid, "fiddler.transformArrayFields", fmt.Errorf("%v not expected type", f), "Not expected type")
 			}
 			lastfield, ok := field["foreign"].(string)
 			if !ok {
-				log.Error(uuid, "transformArrayFields", fmt.Errorf("%v not expected type", field["foreign"]), "Not expected type")
+				log.Error(uuid, "fiddler.transformArrayFields", fmt.Errorf("%v not expected type", field["foreign"]), "Not expected type")
 			}
 			lastfield = strings.ToLower(lastfield)
 
@@ -309,12 +309,12 @@ func transformArrayFields(foreign string, fields interface{}, row map[string]int
 
 			relation, ok := field["relation"].(string)
 			if !ok {
-				log.Error(uuid, "transformArrayFields", fmt.Errorf("%v not expected type", field["relation"]), "Not expected type")
+				log.Error(uuid, "fiddler.transformArrayFields", fmt.Errorf("%v not expected type", field["relation"]), "Not expected type")
 			}
 			relation = strings.ToLower(relation)
 			local, ok := field["local"].(string)
 			if !ok {
-				log.Error(uuid, "transformArrayFields", fmt.Errorf("%v not expected type", field["local"]), "Not expected type")
+				log.Error(uuid, "fiddler.transformArrayFields", fmt.Errorf("%v not expected type", field["local"]), "Not expected type")
 			}
 			local = strings.ToLower(local)
 

--- a/pkg/fiddler/fiddler.go
+++ b/pkg/fiddler/fiddler.go
@@ -43,7 +43,7 @@ func GetID(modelName string) string {
 
 // GetCollections give the names of all the collections in the strategy file
 func GetCollections() []string {
-	tables := strategy.GetTables() // map[string]Table
+	tables := strategy.GetEntities() // map[string]Table
 	keys := []string{}
 	for k := range tables {
 		keys = append(keys, k)
@@ -57,7 +57,7 @@ func TransformRow(row map[string]interface{}, modelName string) (interface{}, []
 	var newRows []map[string]interface{}
 	var err error
 
-	table := strategy.GetTables()[modelName]
+	table := strategy.GetEntities()[modelName]
 	idField := GetID(modelName)
 	id := row[idField]
 

--- a/pkg/fiddler/fiddler_test.go
+++ b/pkg/fiddler/fiddler_test.go
@@ -30,7 +30,7 @@ func setup() {
 		return ll
 	}
 
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel )
 
 	// Mock strategy configuration
 	strategyConf := "../../tests/strategy_test.json"

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -21,7 +21,7 @@ func setup() {
 		return ll
 	}
 
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel )
 }
 
 func teardown() {

--- a/pkg/source/api.go
+++ b/pkg/source/api.go
@@ -157,12 +157,6 @@ func (a API) GetAPIData(pageAfter string) ([]map[string]interface{}, bool, strin
 		return nil, finish, nextPageAfter, err
 	}
 
-	// // continue trying to get the data
-	// if d["errorCode"] == "waiting" {
-	// 	time.Sleep(10 * time.Second)
-	// 	return nil, true, pageAfter, nil
-	// }
-
 	recordsField := credA.GetRecordsFieldName()
 
 	// Emtpy records means there are no more data to send
@@ -192,10 +186,7 @@ func (a API) GetAPIData(pageAfter string) ([]map[string]interface{}, bool, strin
 
 	// TO DO: NEEDS TO MOVE THIS ATTRIBUTES TO THE STRATEGY FILE!!
 	nextPageAfter, ok = d["nextPageAfter"].(string) //strconv.ParseFloat(d["nextPageAfter"].(string), 64)
-	if !ok {
-		finish = true
-		//fmt.Println("DEBUG: no nextPageAfter: ", d)
-	}
+	finish = !ok
 
 	return flattenData, finish, nextPageAfter, err
 }

--- a/pkg/source/api.go
+++ b/pkg/source/api.go
@@ -178,8 +178,8 @@ func (a API) GetQueryData(entityname string, options *Options, ids []string) ([]
 	return d, err
 }
 
-// IsAPI is a func from the Sourcer interface. It tell us if the external source is a database or API
-func (a API) IsAPI() bool {
+// IsWebService is a func from the Sourcer interface. It tell us if the external source is a database or API
+func (a API) IsWebService() bool {
 	return true
 }
 

--- a/pkg/source/api.go
+++ b/pkg/source/api.go
@@ -1,0 +1,250 @@
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/ardanlabs/kit/log"
+	str "github.com/coralproject/sponge/pkg/strategy"
+)
+
+/* Implementing the Sources */
+
+// API is the struct that has the connection string to the external mysql database
+type API struct {
+	Connection string
+}
+
+// while there is data --> GetData (nextPage)
+// send data to channel
+
+// process workers <--- get data from channel
+
+// GetData does the request into the API and get back the data
+// We are not using it because it is specific for a collection
+func (a API) GetData(coralTableName string, offset int, limit int, orderby string, q string) ([]map[string]interface{}, bool, error) {
+
+	notFinish := false
+	var err error
+
+	cred, err := strategy.GetCredential("api", "foreign")
+	if err != nil {
+		log.Error(uuid, "api.getdata", err, "Getting credentials with API")
+	}
+
+	credA, ok := cred.(str.CredentialAPI)
+	if !ok {
+		log.Error(uuid, "api.getdata", err, "Asserting type.")
+	}
+
+	// Build the request
+	req, err := http.NewRequest("GET", a.Connection, nil)
+	if err != nil {
+		log.Error(uuid, "api.getdata", err, "New request.")
+		return nil, notFinish, err
+	}
+	req.Header.Add("User-Agent", credA.GetUserAgent())
+
+	// For control over HTTP client headers,
+	// redirect policy, and other settings,
+	// create a Client
+	// A Client is an HTTP client
+	client := &http.Client{}
+
+	// Send the request via a client
+	// Do sends an HTTP request and
+	// returns an HTTP response
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Error(uuid, "api.getdata", err, "Doing a call to API.")
+		return nil, notFinish, err
+	}
+
+	// Callers should close resp.Body
+	// when done reading from it
+	// Defer the closing of the body
+	defer resp.Body.Close()
+
+	var d map[string]interface{}
+
+	// Use json.Decode for reading streams of JSON data
+	if err = json.NewDecoder(resp.Body).Decode(&d); err != nil {
+		log.Error(uuid, "api.getdata", err, "Decoding data from API.")
+	}
+
+	recordsField := credA.GetRecordsFieldName()
+
+	records, ok := d[recordsField].([]interface{}) //this are all the entries
+	if !ok {
+		log.Error(uuid, "api.getdata", err, "Asserting type.")
+	}
+
+	r := make([]map[string]interface{}, len(records))
+	for _, i := range records { // all the entries in the type we need
+		r = append(r, i.(map[string]interface{}))
+	}
+
+	flattenData, err := normalizeData(r)
+	if err != nil {
+		log.Error(uuid, "api.getdata", err, "Normalizing data from api to fit into fiddler.")
+		return nil, notFinish, err
+	}
+
+	return flattenData, notFinish, err
+}
+
+// GetAPIData use the fire host to constantly give data from the API
+func (a API) GetAPIData(pageAfter string) ([]map[string]interface{}, bool, string, error) {
+	var (
+		flattenData   []map[string]interface{}
+		finish        bool
+		nextPageAfter string
+		err           error
+	)
+
+	finish = false
+
+	// Get the credentials to connect to the API
+	cred, err := strategy.GetCredential("api", "foreign")
+	if err != nil {
+		log.Error(uuid, "api.getdata", err, "Getting credentials with API")
+	}
+
+	// Assert Type into a credential API struct
+	credA, ok := cred.(str.CredentialAPI)
+	if !ok {
+		log.Error(uuid, "api.getdata", err, "Asserting type.")
+	}
+
+	// TO DO: THIS IS VERY WAPO API HARCODED!
+	// We need to insert pageAfter inside the q
+
+	// Build the request
+	req, err := http.NewRequest("GET", a.Connection, nil)
+	if err != nil {
+		log.Error(uuid, "api.getAPIData", err, "New request.")
+		return nil, finish, nextPageAfter, err
+	}
+	req.Header.Add("User-Agent", credA.GetUserAgent())
+
+	// For control over HTTP client headers,
+	// redirect policy, and other settings,
+	// create a Client
+	// A Client is an HTTP client
+	client := &http.Client{}
+
+	// Send the request via a client
+	// Do sends an HTTP request and
+	// returns an HTTP response
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Error(uuid, "api.getdata", err, "Doing a call to API.")
+		return nil, finish, nextPageAfter, err
+	}
+
+	// Callers should close resp.Body
+	// when done reading from it
+	// Defer the closing of the body
+	defer resp.Body.Close()
+
+	var d map[string]interface{}
+
+	// Use json.Decode for reading streams of JSON data
+	if err = json.NewDecoder(resp.Body).Decode(&d); err != nil {
+		log.Error(uuid, "api.getdata", err, "Decoding data from API.")
+		return nil, finish, nextPageAfter, err
+	}
+
+	// // continue trying to get the data
+	// if d["errorCode"] == "waiting" {
+	// 	time.Sleep(10 * time.Second)
+	// 	return nil, true, pageAfter, nil
+	// }
+
+	recordsField := credA.GetRecordsFieldName()
+
+	// Emtpy records means there are no more data to send
+	if d[recordsField] == nil {
+		finish = true
+		return nil, finish, pageAfter, err
+	}
+
+	records, ok := d[recordsField].([]interface{}) //this are all the entries
+	if !ok {
+		log.Error(uuid, "api.getdata", err, "Asserting type.")
+		return nil, finish, nextPageAfter, err
+	}
+
+	//fmt.Printf("DEBUG entries: %s, length %v\n\n\n", recordsField, len(records))
+
+	r := make([]map[string]interface{}, len(records))
+	for _, i := range records { // all the entries in the type we need
+		r = append(r, i.(map[string]interface{}))
+	}
+
+	flattenData, err = normalizeData(r)
+	if err != nil {
+		log.Error(uuid, "api.getdata", err, "Normalizing data from api to fit into fiddler.")
+		return nil, finish, nextPageAfter, err
+	}
+
+	// TO DO: NEEDS TO MOVE THIS ATTRIBUTES TO THE STRATEGY FILE!!
+	nextPageAfter, ok = d["nextPageAfter"].(string) //strconv.ParseFloat(d["nextPageAfter"].(string), 64)
+	if !ok {
+		finish = true
+		//fmt.Println("DEBUG: no nextPageAfter: ", d)
+	}
+
+	return flattenData, finish, nextPageAfter, err
+}
+
+// GetQueryData will return all the data based on a specific list of IDs
+func (a API) GetQueryData(coralTableName string, offset int, limit int, orderby string, ids []string) ([]map[string]interface{}, error) {
+	var d []map[string]interface{}
+	var err error
+
+	return d, err
+}
+
+// IsAPI is a func from the Sourcer interface. It tell us if the external source is a database or API
+func (a API) IsAPI() bool {
+	return true
+}
+
+//////* Not exported functions *//////
+
+// ConnectionMySQL returns the connection string
+func connectionAPI() *url.URL {
+
+	credA, ok := credential.(str.CredentialAPI)
+	if !ok {
+		err := fmt.Errorf("Error when asserting type credentialAPI on credential.")
+		log.Error(uuid, "api.connectionAPI", err, "Asserting type.")
+	}
+
+	basicurl := credA.GetEndpoint()                      //"https://comments-api.ext.nile.works/v1/search"
+	appkey := credA.GetAppKey()                          //"prod.washpost.com"
+	attributes := url.QueryEscape(credA.GetAttributes()) // Attributes for the query. Eg, for WaPo we have scope and sortOrder
+
+	surl := fmt.Sprintf("%s?q=((%s))&appkey=%s", basicurl, attributes, appkey)
+
+	u, err := url.Parse(surl)
+	if err != nil {
+		log.Error(uuid, "api.connectionAPI", err, "Parsing url %s", surl)
+	}
+
+	// u, err := url.Parse(basicurl)
+	// if err != nil {
+	// 	log.Error(uuid, "api.connectionAPI", err, "Parsing basic url %s", basicurl)
+	// }
+	//
+	// q := u.Query()
+	// q.Set("q", attributes)
+	// q.Set("appkey", appkey)
+	//
+	// u.RawQuery = q.Encode()
+
+	return u
+}

--- a/pkg/source/api_test.go
+++ b/pkg/source/api_test.go
@@ -1,0 +1,137 @@
+/* package source_test is doing unit tests for the source package */
+package source
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	str "github.com/coralproject/sponge/pkg/strategy"
+)
+
+var (
+	server  *httptest.Server
+	path    string
+	fakeStr str.Strategy
+)
+
+func mockAPI() {
+
+	// Initialization of stub server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		var err error
+		var d map[string]interface{}
+
+		file, e := ioutil.ReadFile("tests/response.json")
+		if e != nil {
+			fmt.Println("ERROR on setting up response in the test.")
+			os.Exit(1)
+		}
+
+		json.Unmarshal(file, &d)
+		fmt.Println(d)
+
+		// check that the row is what we want it to be
+		switch r.RequestURI {
+		case "/v1/search":
+
+			d = make(map[string]interface{})
+			// look at query parameters
+			// setup d
+			//q=((scope: https://www.washingtonpost.com/lifestyle/style/carolyn-hax-stubborn-60-something-parent-refuses-to-see-a-doctor/2015/09/24/299ec776-5e2d-11e5-9757-e49273f05f65_story.html source:washpost.com itemsPerPage: 100 sortOrder:reverseChronological ))&appkey=dev.washpost.com
+		default:
+			err = errors.New("Bad request")
+		}
+
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		if err == nil {
+			w.WriteHeader(http.StatusOK)
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprintln(w, d)
+	}))
+
+	fmt.Println("DEBUG server url: ", server.URL)
+}
+
+func TestMain(m *testing.M) {
+
+	setupAPI()
+
+	code := m.Run()
+	teardown()
+
+	os.Exit(code)
+}
+
+func TestAPIGetData(t *testing.T) {
+
+	coralTableName := ""
+	offset := 0
+	limit := 0
+	orderby := ""
+	q := ""
+
+	data, _, err := mapi.GetData(coralTableName, offset, limit, orderby, q)
+	if err != nil {
+		t.Fatalf("expected no error, got '%s'.", err)
+	}
+
+	if len(data) == 0 {
+		t.Fatalf("expected some entry, got zero.")
+	}
+
+}
+
+func TestGetAPIData(t *testing.T) {
+	setupAPI()
+
+	pageAfter := "1.399743732"
+
+	// no error
+	data, finish, pageAfter1, err := mapi.GetAPIData(pageAfter)
+	if err != nil {
+		t.Fatalf("expected no error, got '%s'.", err)
+	}
+
+	// data should be []map[string]interface{}
+	expectedlen := 200
+	if len(data) != expectedlen { // this is a setup for the seed data
+		t.Fatalf("expected %d, got %d", expectedlen, len(data))
+	}
+
+	expectedUser := "Duck504"
+	if data[100]["actor.title"] != expectedUser {
+		t.Fatalf("expected %s, got %s", expectedUser, data[100]["actor.title"])
+	}
+
+	if !finish {
+		if pageAfter1 == pageAfter {
+			t.Fatalf("expected different pages %s and %s", pageAfter1, pageAfter)
+		}
+
+		data, _, pageAfter2, err := mapi.GetAPIData(pageAfter1)
+		if err != nil {
+			t.Fatalf("expected no error, got '%s'.", err)
+		}
+
+		expectedlen := 200
+		if len(data) != expectedlen { // this is a setup for the seed data
+			t.Fatalf("expected %d, got %d", expectedlen, len(data))
+		}
+
+		if pageAfter1 == pageAfter2 {
+			t.Fatalf("expected different pages %s and %s", pageAfter1, pageAfter2)
+		}
+
+	}
+}

--- a/pkg/source/mongodb.go
+++ b/pkg/source/mongodb.go
@@ -74,16 +74,16 @@ func (m MongoDB) GetData(entityname string, options *Options) ([]map[string]inte
 	}
 
 	var mquery map[string]interface{}
-	if options.query != "" {
-		err = json.Unmarshal([]byte(options.query), &mquery)
+	if options.Query != "" {
+		err = json.Unmarshal([]byte(options.Query), &mquery)
 		if err != nil {
-			log.Error(uuid, "mongodb.getdata", err, "Unmarshalling query %v", options.query)
+			log.Error(uuid, "mongodb.getdata", err, "Unmarshalling query %v", options.Query)
 			return nil, err
 		}
 	}
 
 	//.Select(fieldsToGet) <--- I'm not using Select because SOME FIELDS IN THE TRANSLATION FILE ARE NOT THE RIGHT ONES TO DO THE SELECT. For example: context.object.0.uri
-	err = col.Find(mquery).Limit(options.limit).All(&data)
+	err = col.Find(mquery).Limit(options.Limit).All(&data)
 	if err != nil {
 		log.Error(uuid, "mongodb.getdata", err, "Getting collection %s.", entityname)
 		return nil, err
@@ -111,7 +111,7 @@ func (m MongoDB) GetQueryData(entity string, options *Options, ids []string) ([]
 		for i, j := range ids {
 			ids[i] = fmt.Sprintf("\"%s\"", j)
 		}
-		options.query = fmt.Sprintf("{\"%s\": {\"$in\":[ %v ] } }", idField, strings.Join(ids, ", "))
+		options.Query = fmt.Sprintf("{\"%s\": {\"$in\":[ %v ] } }", idField, strings.Join(ids, ", "))
 
 		d, err = m.GetData(entity, options)
 	} else {

--- a/pkg/source/mongodb.go
+++ b/pkg/source/mongodb.go
@@ -6,11 +6,10 @@ package source
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/ardanlabs/kit/log"
-	"github.com/stretchr/stew/objects"
+	str "github.com/coralproject/sponge/pkg/strategy"
 	"gopkg.in/mgo.v2"
 )
 
@@ -24,45 +23,42 @@ type MongoDB struct {
 
 /* Exported Functions */
 
-// GetTables gets all the collections names from this data source
-func (m MongoDB) GetTables() ([]string, error) {
-	keys := make([]string, len(strategy.Map.Tables))
-
-	for k, val := range strategy.Map.Tables {
-		keys[val.Priority] = k
-	}
-	return keys, nil
-}
-
 // GetData returns the raw data from the tableName
-func (m MongoDB) GetData(coralTableName string, offset int, limit int, orderby string, query string) ([]map[string]interface{}, error) { //(*sql.Rows, error) {
+func (m MongoDB) GetData(coralTableName string, offset int, limit int, orderby string, query string) ([]map[string]interface{}, bool, error) { //(*sql.Rows, error) {
 
 	var data []map[string]interface{}
+	var notFinish = false
 
-	// Get the corresponding table to the modelName
-	collectionName := strategy.GetTableForeignName(coralTableName)
-	fields := strategy.GetTableForeignFields(coralTableName) //[]]map[string]string
+	// Get the corresponding entity to the coral collection name
+	collectionName := strategy.GetEntityForeignName(coralTableName)
+	fields := strategy.GetEntityForeignFields(coralTableName) //[]]map[string]string
 
 	// open a connection
 	session, err := m.initSession()
 	if err != nil {
 		log.Error(uuid, "source.getdata", err, "Initializing mongo session.")
-		return nil, err
+		return nil, notFinish, err
 	}
 	defer m.closeSession(session)
 
+	credentialD, ok := credential.(str.CredentialDatabase)
+	if !ok {
+		err = fmt.Errorf("Error asserting type CredentialDatabase from interface Credential.")
+		log.Error(uuid, "source.getdata", err, "Asserting Type CredentialDatabase")
+		return nil, notFinish, err
+	}
 	cred := mgo.Credential{
-		Username: credential.Username,
-		Password: credential.Password,
+		Username: credentialD.Username,
+		Password: credentialD.Password,
 	}
 
 	err = session.Login(&cred)
 	if err != nil {
 		log.Error(uuid, "source.getdata", err, "Login mongo session.")
-		return nil, err
+		return nil, notFinish, err
 	}
 
-	db := session.DB(credential.Database)
+	db := session.DB(credentialD.Database)
 	col := db.C(collectionName)
 
 	//Get all the fields that we are going to get from the document { field: 1}
@@ -78,7 +74,7 @@ func (m MongoDB) GetData(coralTableName string, offset int, limit int, orderby s
 		err = json.Unmarshal([]byte(query), &mquery)
 		if err != nil {
 			log.Error(uuid, "mongo.getdata", err, "Unmarshalling query %v", query)
-			return nil, err
+			return nil, notFinish, err
 		}
 	}
 
@@ -86,16 +82,16 @@ func (m MongoDB) GetData(coralTableName string, offset int, limit int, orderby s
 	err = col.Find(mquery).Limit(limit).All(&data)
 	if err != nil {
 		log.Error(uuid, "mongo.getdata", err, "Getting collection %s.", collectionName)
-		return nil, err
+		return nil, notFinish, err
 	}
 
 	flattenData, err := normalizeData(data)
 	if err != nil {
 		log.Error(uuid, "source.getdata", err, "Normalizing data from mongo to fit into fiddler.")
-		return nil, err
+		return nil, notFinish, err
 	}
 
-	return flattenData, nil
+	return flattenData, notFinish, nil
 }
 
 // GetQueryData needs to be implemented for mongodb to implement the sourcer interface
@@ -113,7 +109,7 @@ func (m MongoDB) GetQueryData(coralTableName string, offset int, limit int, orde
 		}
 		query := fmt.Sprintf("{\"%s\": {\"$in\":[ %v ] } }", idField, strings.Join(ids, ", "))
 
-		d, err = m.GetData(coralTableName, offset, limit, orderby, query)
+		d, _, err = m.GetData(coralTableName, offset, limit, orderby, query)
 	} else {
 		err = fmt.Errorf("No ids to get.")
 	}
@@ -121,11 +117,20 @@ func (m MongoDB) GetQueryData(coralTableName string, offset int, limit int, orde
 	return d, err
 }
 
+func (m MongoDB) IsAPI() bool {
+	return false
+}
+
 //////* Not exported functions *//////
 
 // ConnectionMongoDB returns the connection string
 func connectionMongoDB() string {
-	return fmt.Sprintf("%s:%s@/%s", credential.Username, credential.Password, credential.Database)
+	credentialD, ok := credential.(str.CredentialDatabase)
+	if !ok {
+		log.Error(uuid, "source.getdata", fmt.Errorf("Error asserting type CredentialDatabase from interface Credential."), "Asserting Type CredentialDatabase")
+		return ""
+	}
+	return fmt.Sprintf("%s:%s@/%s", credentialD.Username, credentialD.Password, credentialD.Database)
 }
 
 // Open gives back a pointer to the DB
@@ -145,154 +150,4 @@ func (m *MongoDB) initSession() (*mgo.Session, error) {
 // Close closes the db
 func (m MongoDB) closeSession(session *mgo.Session) {
 	session.Close()
-}
-
-// it prepares the data to have the transformations in fiddler
-// normalize converts into a map[string]string with the key a breadcrumb to the leaf, and the value being the leaf itself
-func flattenData(fields []string, mongoData []map[string]interface{}) ([]map[string]interface{}, error) {
-	var dat []map[string]interface{}
-
-	for _, j := range mongoData { // this is a slice of maps
-		d, e := flattDocument(fields, j)
-		if e != nil {
-			return nil, e
-		}
-		// add d to dat
-		dat = append(dat, d)
-	}
-
-	return dat, nil
-}
-
-func flattDocument(fields []string, document map[string]interface{}) (map[string]interface{}, error) {
-
-	var err error
-	result := make(map[string]interface{})
-
-	for _, field := range fields {
-		result[field] = objects.Map(document).Get(field)
-	}
-
-	return result, err
-}
-
-// it prepares the data to have the transformations in fiddler
-// normalize converts into a map[string]string with the key a breadcrumb to the leaf, and the value being the leaf itself
-func normalizeData(mongoData []map[string]interface{}) ([]map[string]interface{}, error) {
-	var dat []map[string]interface{}
-
-	for _, j := range mongoData { // this is a slice of maps
-		d, e := normalizeDocument(j)
-		if e != nil {
-			return nil, e
-		}
-		// add d to dat
-		dat = append(dat, d)
-	}
-
-	return dat, nil
-}
-
-func normalizeDocument(document map[string]interface{}) (map[string]interface{}, error) {
-	d := make(map[string]interface{})
-
-	for i, k := range document { // this is the actual map
-		//fmt.Printf("## Index %s, normalizing %v \n\n", i, k)
-		m := normalize(i, k) // gets the id being the breadcrumb and val the leaf
-		//fmt.Printf("- Got %v\n\n\n", m)
-		for r, p := range m {
-			d[r] = p
-		}
-	}
-
-	return d, nil
-}
-
-// i is the first key. k could be a string or a map
-// it returns key and value
-func normalize(i string, k interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
-
-	switch v := k.(type) {
-	case map[string]interface{}: // if k is a map then go deeper
-		//fmt.Printf("** %v is map[string]interface{}\n\n", k)
-		for p, e := range k.(map[string]interface{}) {
-			switch v := e.(type) {
-			case map[string]interface{}:
-				//fmt.Printf("* %v is map[string]interface{}\n\n", e)
-				newi := strings.Join([]string{i, p}, ".")
-				newresult := normalize(newi, e)
-				// copy newresult into result
-				for v1, v2 := range newresult {
-					result[v1] = v2
-				}
-			case []map[string]interface{}:
-				//fmt.Printf("* %v is []map[string]interface{}\n\n", e)
-				for u, c := range v {
-					newi := strings.Join([]string{i, p, strconv.Itoa(u)}, ".")
-					newresult := normalize(newi, c)
-					for v1, v2 := range newresult {
-						result[v1] = v2
-					}
-				}
-			case map[string]string:
-				//fmt.Printf("* %v is map[string]string\n\n", e)
-				for a, b := range v {
-					newi := strings.Join([]string{i, p, a}, ".")
-					result[newi] = b
-				}
-			case []map[string]string:
-				//fmt.Printf("* %v is []map[string]string\n\n", e)
-				for u, c := range v {
-					newi := strings.Join([]string{i, p, strconv.Itoa(u)}, ".")
-					newresult := normalize(newi, c)
-					for v1, v2 := range newresult {
-						result[v1] = v2
-					}
-				}
-			case []interface{}:
-				//fmt.Printf("* %v is []interface{}\n\n", e)
-				for d1, d2 := range v {
-					newi := strings.Join([]string{i, p, strconv.Itoa(d1)}, ".")
-					newresult := normalize(newi, d2)
-					for v1, v2 := range newresult {
-						result[v1] = v2
-					}
-				}
-			default:
-				// fmt.Printf("* %v is no idea\n\n", e)
-				// fmt.Println(reflect.TypeOf(v))
-				newi := strings.Join([]string{i, p}, ".")
-				result[newi] = e
-			}
-		}
-	case map[string]string:
-		//fmt.Printf("** %v is map[string]string\n\n", k)
-		for p, e := range v {
-			newi := strings.Join([]string{i, p}, ".")
-			result[newi] = e
-		}
-	case []map[string]string:
-		//fmt.Printf("** %v is []map[string]string\n\n", k)
-		for u, c := range v {
-			newi := strings.Join([]string{i, strconv.Itoa(u)}, ".")
-			newresult := normalize(newi, c)
-			for v1, v2 := range newresult {
-				result[v1] = v2
-			}
-		}
-	case []map[string]interface{}:
-		for u, c := range v {
-			newi := strings.Join([]string{i, strconv.Itoa(u)}, ".")
-			newresult := normalize(newi, c)
-			for v1, v2 := range newresult {
-				result[v1] = v2
-			}
-		}
-	default: // if k is not a map then just return it as a string
-		//fmt.Printf("** %v is no idea\n\n", k)
-		result[i] = k
-	}
-
-	return result
 }

--- a/pkg/source/mongodb.go
+++ b/pkg/source/mongodb.go
@@ -121,8 +121,8 @@ func (m MongoDB) GetQueryData(entity string, options *Options, ids []string) ([]
 	return d, err
 }
 
-// IsAPI is used to check what is that sourcerer interface
-func (m MongoDB) IsAPI() bool {
+// IsWebService is used to check what is that sourcerer interface
+func (m MongoDB) IsWebService() bool {
 	return false
 }
 

--- a/pkg/source/mongodb_test.go
+++ b/pkg/source/mongodb_test.go
@@ -10,13 +10,14 @@ func TestMongoGetData(t *testing.T) {
 
 	// Default Flags
 	coralName := "comments"
-	offset := 0
-	limit := 9999999999
-	orderby := ""
-	query := ""
+	options := &Options{offset: 0,
+		limit:   9999999999,
+		orderby: "",
+		query:   "",
+	}
 
 	// no error
-	data, _, err := mdb.GetData(coralName, offset, limit, orderby, query)
+	data, err := mdb.GetData(coralName, options)
 	if err != nil {
 		t.Fatalf("expected no error, got '%s'.", err)
 	}
@@ -33,13 +34,14 @@ func TestMongoQueryGetData(t *testing.T) {
 
 	// Default Flags
 	coralName := "comments"
-	offset := 0
-	limit := 9999999999
-	orderby := ""
-	query := "{ \"updated\": { \"$gt\": \"2013-01-02 15:04:05\", \"$lt\": \"2016-01-02 15:04:05\" } }"
-
+	options := &Options{
+		offset:  0,
+		limit:   9999999999,
+		orderby: "",
+		query:   "{ \"updated\": { \"$gt\": \"2013-01-02 15:04:05\", \"$lt\": \"2016-01-02 15:04:05\" } }",
+	}
 	// no error
-	data, _, err := mdb.GetData(coralName, offset, limit, orderby, query)
+	data, err := mdb.GetData(coralName, options)
 	if err != nil {
 		t.Fatalf("expected no error, got '%s'.", err)
 	}
@@ -57,13 +59,13 @@ func TestMongoGetQueryData(t *testing.T) {
 
 	// Default Flags
 	coralName := "comments"
-	offset := 0
-	limit := 9999999999
-	orderby := ""
+	options := &Options{offset: 0,
+		limit:   9999999999,
+		orderby: ""}
 	ids := []string{"56ac0c7010780b0a357bdec3", "56ac0c7010780b0a357bdec1", "56ac0c7010780b0a357bdec4"}
 
 	// no error
-	data, err := mdb.GetQueryData(coralName, offset, limit, orderby, ids)
+	data, err := mdb.GetQueryData(coralName, options, ids)
 	if err != nil {
 		t.Fatalf("expected no error, got '%s'.", err)
 	}

--- a/pkg/source/mongodb_test.go
+++ b/pkg/source/mongodb_test.go
@@ -9,20 +9,20 @@ func TestMongoGetData(t *testing.T) {
 	setupMongo()
 
 	// Default Flags
-	coralName := "comment"
+	coralName := "comments"
 	offset := 0
 	limit := 9999999999
 	orderby := ""
 	query := ""
 
 	// no error
-	data, err := mdb.GetData(coralName, offset, limit, orderby, query)
+	data, _, err := mdb.GetData(coralName, offset, limit, orderby, query)
 	if err != nil {
 		t.Fatalf("expected no error, got '%s'.", err)
 	}
 
 	// data should be []map[string]interface{}
-	expectedlen := 0
+	expectedlen := 150901
 	if len(data) != expectedlen { // this is a setup for the seed data
 		t.Fatalf("expected %d, got %d", expectedlen, len(data))
 	}
@@ -32,14 +32,14 @@ func TestMongoQueryGetData(t *testing.T) {
 	setupMongo()
 
 	// Default Flags
-	coralName := "comment"
+	coralName := "comments"
 	offset := 0
 	limit := 9999999999
 	orderby := ""
 	query := "{ \"updated\": { \"$gt\": \"2013-01-02 15:04:05\", \"$lt\": \"2016-01-02 15:04:05\" } }"
 
 	// no error
-	data, err := mdb.GetData(coralName, offset, limit, orderby, query)
+	data, _, err := mdb.GetData(coralName, offset, limit, orderby, query)
 	if err != nil {
 		t.Fatalf("expected no error, got '%s'.", err)
 	}
@@ -56,7 +56,7 @@ func TestMongoGetQueryData(t *testing.T) {
 	setupMongo()
 
 	// Default Flags
-	coralName := "comment"
+	coralName := "comments"
 	offset := 0
 	limit := 9999999999
 	orderby := ""
@@ -75,27 +75,27 @@ func TestMongoGetQueryData(t *testing.T) {
 	}
 }
 
-// Signature func (m MongoDB) GetTables() ([]string, error) {
-func TestMongoGetTables(t *testing.T) {
+// Signature func (m MongoDB) GetEntities() ([]string, error) {
+func TestMongoGetEntities(t *testing.T) {
 
 	setupMongo()
 
-	s, e := mdb.GetTables()
+	s, e := GetEntities()
 	if e != nil {
 		t.Fatalf("expected no error, got %s.", e)
 	}
 
-	expectedLen := 3
+	expectedLen := 4
 	if len(s) != expectedLen {
 		t.Fatalf("got %d, it should be %d", len(s), expectedLen)
 	}
 
-	if s[0] != "asset" {
+	if s[0] != "users" {
 		t.Fatalf("got %s, it should be asset", s[0])
 	}
 
-	if s[2] != "comment" {
-		t.Fatalf("got %s, it should be asset", s[0])
+	if s[1] != "comments" {
+		t.Fatalf("got %s, it should be comments", s[1])
 	}
 
 	teardown()

--- a/pkg/source/mysql.go
+++ b/pkg/source/mysql.go
@@ -50,18 +50,18 @@ func (m MySQL) GetData(entityname string, options *Options) ([]map[string]interf
 	}
 
 	fields := strings.Join(f, ", ")
-	if options.orderby == "" {
-		options.orderby = strategy.GetOrderBy(entityname)
+	if options.Orderby == "" {
+		options.Orderby = strategy.GetOrderBy(entityname)
 	}
 
 	// Get only the fields that we are going to use
 	// the query string . To Do. Select only the stuff you are going to use
 	//query := strings.Join([]string{"SELECT", fields, "from", tableName, "order by", orderby, "limit", fmt.Sprintf("%v", offset), ", ", fmt.Sprintf("%v", limit)}, " ")
 	var where string
-	if options.query != "" {
-		where = fmt.Sprintf("where %s ", options.query)
+	if options.Query != "" {
+		where = fmt.Sprintf("where %s ", options.Query)
 	}
-	query := fmt.Sprintf("SELECT %s from %s %s order by %s limit %v, %v", fields, tableName, where, options.orderby, options.offset, options.limit)
+	query := fmt.Sprintf("SELECT %s from %s %s order by %s limit %v, %v", fields, tableName, where, options.Orderby, options.Offset, options.Limit)
 
 	data, err := gosqljson.QueryDbToMapJSON(db, "lower", query)
 	if err != nil {
@@ -108,8 +108,8 @@ func (m MySQL) GetQueryData(entityname string, options *Options, ids []string) (
 	fields := strings.Join(f, ", ")
 
 	// if we are ordering by
-	if len(options.orderby) == 0 {
-		options.orderby = strategy.GetOrderBy(entityname)
+	if len(options.Orderby) == 0 {
+		options.Orderby = strategy.GetOrderBy(entityname)
 	}
 
 	var queryWhere string
@@ -121,7 +121,7 @@ func (m MySQL) GetQueryData(entityname string, options *Options, ids []string) (
 
 	// Get only the fields that we are going to use
 	// the query string . To Do. Select only the stuff you are going to use
-	query := strings.Join([]string{"SELECT", fields, "from", tableName, queryWhere, "order by", options.orderby, "limit", fmt.Sprintf("%v", options.offset), ", ", fmt.Sprintf("%v", options.limit)}, " ")
+	query := strings.Join([]string{"SELECT", fields, "from", tableName, queryWhere, "order by", options.Orderby, "limit", fmt.Sprintf("%v", options.Offset), ", ", fmt.Sprintf("%v", options.Limit)}, " ")
 
 	data, err := gosqljson.QueryDbToMapJSON(db, "lower", query)
 	if err != nil {

--- a/pkg/source/mysql.go
+++ b/pkg/source/mysql.go
@@ -141,8 +141,8 @@ func (m MySQL) GetQueryData(entityname string, options *Options, ids []string) (
 	return dat, nil
 }
 
-// IsAPI returns true only if the implementation of Sourcer is an API
-func (m MySQL) IsAPI() bool {
+// IsWebService returns true only if the implementation of Sourcer is an API
+func (m MySQL) IsWebService() bool {
 	return false
 }
 

--- a/pkg/source/mysql_test.go
+++ b/pkg/source/mysql_test.go
@@ -36,13 +36,13 @@ func TestGetData(t *testing.T) {
 
 	// Default Flags
 	coralName := "comments"
-	offset := 0
-	limit := 9999999999
-	orderby := "createdate"
-	query := ""
+	options := &Options{offset: 0,
+		limit:   9999999999,
+		orderby: "createdate",
+		query:   ""}
 
 	// no error
-	data, _, err := mm.GetData(coralName, offset, limit, orderby, query)
+	data, err := mm.GetData(coralName, options)
 	if err != nil {
 		t.Fatalf("expected no error, got %s.", err)
 	}
@@ -62,13 +62,15 @@ func TestQueryGetData(t *testing.T) {
 
 	// Default Flags
 	coralName := "assets"
-	offset := 0
-	limit := 9999999999
-	orderby := ""
-	query := "updatedate > 2013-12-12"
+	options := &Options{
+		offset:  0,
+		limit:   9999999999,
+		orderby: "",
+		query:   "updatedate > 2013-12-12",
+	}
 
 	// no error
-	data, _, err := mm.GetData(coralName, offset, limit, orderby, query)
+	data, err := mm.GetData(coralName, options)
 	if err != nil {
 		t.Fatalf("expected no error, got %s.", err)
 	}

--- a/pkg/source/mysql_test.go
+++ b/pkg/source/mysql_test.go
@@ -8,7 +8,7 @@ func TestGetTables(t *testing.T) {
 
 	setupMysql()
 
-	s, e := mm.GetTables()
+	s, e := GetEntities()
 	if e != nil {
 		t.Fatalf("expected no error, got %s.", e)
 	}
@@ -18,12 +18,12 @@ func TestGetTables(t *testing.T) {
 		t.Fatalf("got %d, it should be %d", len(s), expectedLen)
 	}
 
-	if s[0] != "asset" {
-		t.Fatalf("got %s, it should be asset", s[0])
+	if s[0] != "assets" {
+		t.Fatalf("got %s, it should be assets", s[0])
 	}
 
-	if s[2] != "comment" {
-		t.Fatalf("got %s, it should be asset", s[0])
+	if s[2] != "comments" {
+		t.Fatalf("got %s, it should be comments", s[0])
 	}
 
 	teardown()
@@ -35,14 +35,14 @@ func TestGetData(t *testing.T) {
 	setupMysql()
 
 	// Default Flags
-	coralName := "comment"
+	coralName := "comments"
 	offset := 0
 	limit := 9999999999
-	orderby := ""
+	orderby := "createdate"
 	query := ""
 
 	// no error
-	data, err := mm.GetData(coralName, offset, limit, orderby, query)
+	data, _, err := mm.GetData(coralName, offset, limit, orderby, query)
 	if err != nil {
 		t.Fatalf("expected no error, got %s.", err)
 	}
@@ -61,14 +61,14 @@ func TestQueryGetData(t *testing.T) {
 	setupMysql()
 
 	// Default Flags
-	coralName := "asset"
+	coralName := "assets"
 	offset := 0
 	limit := 9999999999
 	orderby := ""
 	query := "updatedate > 2013-12-12"
 
 	// no error
-	data, err := mm.GetData(coralName, offset, limit, orderby, query)
+	data, _, err := mm.GetData(coralName, offset, limit, orderby, query)
 	if err != nil {
 		t.Fatalf("expected no error, got %s.", err)
 	}

--- a/pkg/source/postgresql.go
+++ b/pkg/source/postgresql.go
@@ -140,8 +140,8 @@ func (p PostgreSQL) GetQueryData(entityname string, options *Options, ids []stri
 	return dat, nil
 }
 
-// IsAPI is a func from the Sourcer interface to check if the external source is api or database
-func (p PostgreSQL) IsAPI() bool {
+// IsWebService is a func from the Sourcer interface to check if the external source is api or database
+func (p PostgreSQL) IsWebService() bool {
 	return false
 }
 

--- a/pkg/source/postgresql.go
+++ b/pkg/source/postgresql.go
@@ -50,17 +50,17 @@ func (p PostgreSQL) GetData(entityname string, options *Options) ([]map[string]i
 	}
 
 	fields := strings.Join(f, ", ")
-	if options.orderby == "" {
-		options.orderby = strategy.GetOrderBy(entityname)
+	if options.Orderby == "" {
+		options.Orderby = strategy.GetOrderBy(entityname)
 	}
 
 	// Get only the fields that we are going to use
 	var where string
-	if options.query != "" {
-		where = fmt.Sprintf("where %s ", options.query)
+	if options.Query != "" {
+		where = fmt.Sprintf("where %s ", options.Query)
 	}
 
-	query := fmt.Sprintf("SELECT %s from %s %s order by %s OFFSET %v LIMIT %v", fields, tableName, where, options.orderby, options.offset, options.limit)
+	query := fmt.Sprintf("SELECT %s from %s %s order by %s OFFSET %v LIMIT %v", fields, tableName, where, options.Orderby, options.Offset, options.Limit)
 
 	data, err := gosqljson.QueryDbToMapJSON(db, "lower", query)
 	if err != nil {
@@ -107,8 +107,8 @@ func (p PostgreSQL) GetQueryData(entityname string, options *Options, ids []stri
 	fields := strings.Join(f, ", ")
 
 	// if we are ordering by
-	if len(options.orderby) == 0 {
-		options.orderby = strategy.GetOrderBy(entityname)
+	if len(options.Orderby) == 0 {
+		options.Orderby = strategy.GetOrderBy(entityname)
 	}
 
 	var queryWhere string
@@ -120,7 +120,7 @@ func (p PostgreSQL) GetQueryData(entityname string, options *Options, ids []stri
 
 	// Get only the fields that we are going to use
 	// the query string . To Do. Select only the stuff you are going to use
-	query := strings.Join([]string{"SELECT", fields, "from", tableName, queryWhere, "order by", options.orderby, "limit", fmt.Sprintf("%v", options.offset), ", ", fmt.Sprintf("%v", options.limit)}, " ")
+	query := strings.Join([]string{"SELECT", fields, "from", tableName, queryWhere, "order by", options.Orderby, "limit", fmt.Sprintf("%v", options.Offset), ", ", fmt.Sprintf("%v", options.Limit)}, " ")
 
 	data, err := gosqljson.QueryDbToMapJSON(db, "lower", query)
 	if err != nil {

--- a/pkg/source/postgresql_test.go
+++ b/pkg/source/postgresql_test.go
@@ -36,13 +36,15 @@ func TestPostgresGetData(t *testing.T) {
 
 	// Default Flags
 	coralName := "users"
-	offset := 0
-	limit := 9999999999
-	var orderby string
-	var query string
+	options := &Options{
+		offset:  0,
+		limit:   9999999999,
+		orderby: "",
+		query:   "",
+	}
 
 	// no error
-	data,_, err := mp.GetData(coralName, offset, limit, orderby, query)
+	data, err := mp.GetData(coralName, options)
 	if err != nil {
 		t.Fatalf("expected no error, got %s.", err)
 	}

--- a/pkg/source/postgresql_test.go
+++ b/pkg/source/postgresql_test.go
@@ -8,7 +8,7 @@ func TestPostgresGetTables(t *testing.T) {
 
 	setupPostgreSQL()
 
-	s, e := mp.GetTables()
+	s, e := GetEntities()
 	if e != nil {
 		t.Fatalf("expected no error, got %s.", e)
 	}
@@ -42,7 +42,7 @@ func TestPostgresGetData(t *testing.T) {
 	var query string
 
 	// no error
-	data, err := mp.GetData(coralName, offset, limit, orderby, query)
+	data,_, err := mp.GetData(coralName, offset, limit, orderby, query)
 	if err != nil {
 		t.Fatalf("expected no error, got %s.", err)
 	}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -18,6 +18,18 @@ import (
 	"github.com/stretchr/stew/objects"
 )
 
+// Options will hold all the options that came from flags
+type Options struct {
+	limit                 int
+	offset                int
+	orderby               string
+	query                 string
+	types                 string
+	importonlyfailed      bool
+	reportOnFailedRecords bool
+	reportdbfile          string
+}
+
 // global variables related to strategy
 var (
 	strategy str.Strategy
@@ -52,8 +64,9 @@ func Init(u string) (string, error) {
 
 // Sourcer is where the data is coming from (mysql, api)
 type Sourcer interface {
-	GetData(string, int, int, string, string) ([]map[string]interface{}, bool, error) //tableName, offset, limit, orderby
-	GetQueryData(string, int, int, string, []string) ([]map[string]interface{}, error)
+	// GetData returns data for a specific entity filter by all the options
+	GetData(string, *Options) ([]map[string]interface{}, error)                //int, int, string, string // args ...interface{}) ([]map[string]interface{}, error) //
+	GetQueryData(string, *Options, []string) ([]map[string]interface{}, error) //int, int, string
 	IsAPI() bool
 }
 

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -36,7 +36,7 @@ var (
 	uuid     string
 )
 
-// Global configuration variables that holds the credentials for the foreign database connection
+// Global configuration variables that holds the credentials for the foreign data source connection
 var credential str.Credential
 
 // Init initialize the needed variables
@@ -62,12 +62,12 @@ func Init(u string) (string, error) {
 	return strategy.Map.Foreign, err
 }
 
-// Sourcer is where the data is coming from (mysql, api)
+// Sourcer is where the data is coming from (webservice or database)
 type Sourcer interface {
 	// GetData returns data for a specific entity filter by all the options
 	GetData(string, *Options) ([]map[string]interface{}, error)                //int, int, string, string // args ...interface{}) ([]map[string]interface{}, error) //
 	GetQueryData(string, *Options, []string) ([]map[string]interface{}, error) //int, int, string
-	IsAPI() bool
+	IsWebService() bool
 }
 
 // New returns a new Source struct with the connection string in it

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -20,14 +20,14 @@ import (
 
 // Options will hold all the options that came from flags
 type Options struct {
-	limit                 int
-	offset                int
-	orderby               string
-	query                 string
-	types                 string
-	importonlyfailed      bool
-	reportOnFailedRecords bool
-	reportdbfile          string
+	Limit                 int
+	Offset                int
+	Orderby               string
+	Query                 string
+	Types                 string
+	Importonlyfailed      bool
+	ReportOnFailedRecords bool
+	Reportdbfile          string
 }
 
 // global variables related to strategy

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -10,9 +10,12 @@ package source
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/ardanlabs/kit/log"
 	str "github.com/coralproject/sponge/pkg/strategy"
+	"github.com/stretchr/stew/objects"
 )
 
 // global variables related to strategy
@@ -22,7 +25,7 @@ var (
 )
 
 // Global configuration variables that holds the credentials for the foreign database connection
-var credential str.CredentialDatabase
+var credential str.Credential
 
 // Init initialize the needed variables
 func Init(u string) (string, error) {
@@ -49,9 +52,9 @@ func Init(u string) (string, error) {
 
 // Sourcer is where the data is coming from (mysql, api)
 type Sourcer interface {
-	GetData(string, int, int, string, string) ([]map[string]interface{}, error) //tableName, offset, limit, orderby
+	GetData(string, int, int, string, string) ([]map[string]interface{}, bool, error) //tableName, offset, limit, orderby
 	GetQueryData(string, int, int, string, []string) ([]map[string]interface{}, error)
-	GetTables() ([]string, error)
+	IsAPI() bool
 }
 
 // New returns a new Source struct with the connection string in it
@@ -67,18 +70,177 @@ func New(d string) (Sourcer, error) {
 	case "postgresql":
 		// Get MySQL connection string
 		return PostgreSQL{Connection: connectionPostgreSQL(), Database: nil}, nil
+	case "api":
+		// Get API connection url
+		u := connectionAPI()
+		return API{Connection: u.String()}, nil
 	}
 
 	return nil, fmt.Errorf("Configuration not found for source database %s.", d)
 }
 
-// GetTables gets all the tables names from this data source
-func GetTables() ([]string, error) {
+// GetEntities gets all the entities names from this data source
+func GetEntities() ([]string, error) {
 
-	keys := make([]string, len(strategy.Map.Tables))
+	collections := strategy.GetEntities()
 
-	for k, val := range strategy.Map.Tables {
+	keys := make([]string, len(collections))
+
+	for k, val := range collections {
 		keys[val.Priority] = k
 	}
+
 	return keys, nil
+}
+
+//**** Utility functions used for the API and Mongo GetData func ****//
+
+// it prepares the data to have the transformations in fiddler
+// normalize converts into a map[string]string with the key a breadcrumb to the leaf, and the value being the leaf itself
+func flattenData(fields []string, mongoData []map[string]interface{}) ([]map[string]interface{}, error) {
+	var dat []map[string]interface{}
+
+	for _, j := range mongoData { // this is a slice of maps
+		d, e := flattDocument(fields, j)
+		if e != nil {
+			return nil, e
+		}
+		// add d to dat
+		dat = append(dat, d)
+	}
+
+	return dat, nil
+}
+
+func flattDocument(fields []string, document map[string]interface{}) (map[string]interface{}, error) {
+
+	var err error
+	result := make(map[string]interface{})
+
+	for _, field := range fields {
+		result[field] = objects.Map(document).Get(field)
+	}
+
+	return result, err
+}
+
+// it prepares the data to have the transformations in fiddler
+// normalize converts into a map[string]string with the key a breadcrumb to the leaf, and the value being the leaf itself
+func normalizeData(mongoData []map[string]interface{}) ([]map[string]interface{}, error) {
+	var dat []map[string]interface{}
+
+	for _, j := range mongoData { // this is a slice of maps
+		d, e := normalizeDocument(j)
+		if e != nil {
+			return nil, e
+		}
+		// add d to dat
+		dat = append(dat, d)
+	}
+
+	return dat, nil
+}
+
+func normalizeDocument(document map[string]interface{}) (map[string]interface{}, error) {
+	d := make(map[string]interface{})
+
+	for i, k := range document { // this is the actual map
+		//fmt.Printf("## Index %s, normalizing %v \n\n", i, k)
+		m := normalize(i, k) // gets the id being the breadcrumb and val the leaf
+		//fmt.Printf("- Got %v\n\n\n", m)
+		for r, p := range m {
+			d[r] = p
+		}
+	}
+
+	return d, nil
+}
+
+// i is the first key. k could be a string or a map
+// it returns key and value
+func normalize(i string, k interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	switch v := k.(type) {
+	case map[string]interface{}: // if k is a map then go deeper
+		//fmt.Printf("** %v is map[string]interface{}\n\n", k)
+		for p, e := range k.(map[string]interface{}) {
+			switch v := e.(type) {
+			case map[string]interface{}:
+				//fmt.Printf("* %v is map[string]interface{}\n\n", e)
+				newi := strings.Join([]string{i, p}, ".")
+				newresult := normalize(newi, e)
+				// copy newresult into result
+				for v1, v2 := range newresult {
+					result[v1] = v2
+				}
+			case []map[string]interface{}:
+				//fmt.Printf("* %v is []map[string]interface{}\n\n", e)
+				for u, c := range v {
+					newi := strings.Join([]string{i, p, strconv.Itoa(u)}, ".")
+					newresult := normalize(newi, c)
+					for v1, v2 := range newresult {
+						result[v1] = v2
+					}
+				}
+			case map[string]string:
+				//fmt.Printf("* %v is map[string]string\n\n", e)
+				for a, b := range v {
+					newi := strings.Join([]string{i, p, a}, ".")
+					result[newi] = b
+				}
+			case []map[string]string:
+				//fmt.Printf("* %v is []map[string]string\n\n", e)
+				for u, c := range v {
+					newi := strings.Join([]string{i, p, strconv.Itoa(u)}, ".")
+					newresult := normalize(newi, c)
+					for v1, v2 := range newresult {
+						result[v1] = v2
+					}
+				}
+			case []interface{}:
+				//fmt.Printf("* %v is []interface{}\n\n", e)
+				for d1, d2 := range v {
+					newi := strings.Join([]string{i, p, strconv.Itoa(d1)}, ".")
+					newresult := normalize(newi, d2)
+					for v1, v2 := range newresult {
+						result[v1] = v2
+					}
+				}
+			default:
+				// fmt.Printf("* %v is no idea\n\n", e)
+				// fmt.Println(reflect.TypeOf(v))
+				newi := strings.Join([]string{i, p}, ".")
+				result[newi] = e
+			}
+		}
+	case map[string]string:
+		//fmt.Printf("** %v is map[string]string\n\n", k)
+		for p, e := range v {
+			newi := strings.Join([]string{i, p}, ".")
+			result[newi] = e
+		}
+	case []map[string]string:
+		//fmt.Printf("** %v is []map[string]string\n\n", k)
+		for u, c := range v {
+			newi := strings.Join([]string{i, strconv.Itoa(u)}, ".")
+			newresult := normalize(newi, c)
+			for v1, v2 := range newresult {
+				result[v1] = v2
+			}
+		}
+	case []map[string]interface{}:
+		for u, c := range v {
+			newi := strings.Join([]string{i, strconv.Itoa(u)}, ".")
+			newresult := normalize(newi, c)
+			for v1, v2 := range newresult {
+				result[v1] = v2
+			}
+		}
+	default: // if k is not a map then just return it as a string
+		//fmt.Printf("** %v is no idea\n\n", k)
+		result[i] = k
+	}
+
+	return result
 }

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -33,7 +33,7 @@ func init() {
 		return ll
 	}
 
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel)
 }
 
 func setupMysql() {
@@ -46,7 +46,7 @@ func setupMysql() {
 		}
 		return ll
 	}
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel)
 
 	oStrategy = os.Getenv("STRATEGY_CONF")
 
@@ -86,7 +86,7 @@ func setupMongo() {
 		}
 		return ll
 	}
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel)
 
 	oStrategy = os.Getenv("STRATEGY_CONF")
 
@@ -126,7 +126,7 @@ func setupPostgreSQL() {
 		}
 		return ll
 	}
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel)
 
 	oStrategy = os.Getenv("STRATEGY_CONF")
 
@@ -159,7 +159,7 @@ func setupPostgreSQL() {
 func setupAPI() {
 
 	// Mock the API Server
-	mockAPI()
+	serverurl := mockAPI()
 
 	// Initialize logging
 	logLevel := func() int {
@@ -169,7 +169,7 @@ func setupAPI() {
 		}
 		return ll
 	}
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel)
 
 	oStrategy = os.Getenv("STRATEGY_CONF")
 
@@ -188,7 +188,7 @@ func setupAPI() {
 		fmt.Printf("Error when initializing strategy, %v.\n", e)
 	}
 
-	m, e := New(s) // function being tested
+	m, e := New(s)
 	if e != nil {
 		fmt.Printf("Error when calling the function, %v.\n", e)
 	}
@@ -197,6 +197,7 @@ func setupAPI() {
 	if !ok {
 		fmt.Println("It should return a type API")
 	}
+	mapi.Connection = serverurl + "/v1/search?q=((scope%3Ahttps%3A%2F%2Fwww.washingtonpost.com%2Flifestyle%2Fstyle%2Fcarolyn-hax-stubborn-60-something-parent-refuses-to-see-a-doctor%2F2015%2F09%2F24%2F299ec776-5e2d-11e5-9757-e49273f05f65_story.html+source%3Awashpost.com+itemsPerPage%3A100+sortOrder%3AreverseChronological))&appkey=dev.washpost.com"
 
 }
 

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -15,10 +15,11 @@ const (
 )
 
 var (
-	m   Sourcer
-	mm  MySQL
-	mdb MongoDB
-	mp  PostgreSQL
+	m    Sourcer
+	mm   MySQL
+	mdb  MongoDB
+	mp   PostgreSQL
+	mapi API
 )
 
 var oStrategy string
@@ -111,7 +112,7 @@ func setupMongo() {
 
 	mdb, ok = m.(MongoDB)
 	if !ok {
-		fmt.Println("It should return a type MySQL")
+		fmt.Println("It should return a type MontoDB")
 	}
 }
 
@@ -153,6 +154,50 @@ func setupPostgreSQL() {
 	if !ok {
 		fmt.Println("It should return a type PostgreSQL")
 	}
+}
+
+func setupAPI() {
+
+	// Mock the API Server
+	mockAPI()
+
+	// Initialize logging
+	logLevel := func() int {
+		ll, err := cfg.Int(cfgLoggingLevel)
+		if err != nil {
+			return log.USER
+		}
+		return ll
+	}
+	log.Init(os.Stderr, logLevel, log.Ldefault)
+
+	oStrategy = os.Getenv("STRATEGY_CONF")
+
+	// MOCK STRATEGY CONF
+	strategyConf := os.Getenv("GOPATH") + "/src/github.com/coralproject/sponge/tests/strategy_wapo_api_test.json"
+	e := os.Setenv("STRATEGY_CONF", strategyConf)
+	if e != nil {
+		fmt.Println("It could not setup the mock strategy conf variable")
+	}
+
+	var ok bool
+
+	u := uuidimported.New()
+	s, e := Init(u)
+	if e != nil {
+		fmt.Printf("Error when initializing strategy, %v.\n", e)
+	}
+
+	m, e := New(s) // function being tested
+	if e != nil {
+		fmt.Printf("Error when calling the function, %v.\n", e)
+	}
+
+	mapi, ok = m.(API)
+	if !ok {
+		fmt.Println("It should return a type API")
+	}
+
 }
 
 func teardown() {

--- a/pkg/sponge/sponge.go
+++ b/pkg/sponge/sponge.go
@@ -150,7 +150,7 @@ func importAll() {
 		return
 	}
 
-	if dbsource.IsAPI() {
+	if dbsource.IsWebService() {
 		importFromAPI(collections)
 		return
 	}

--- a/pkg/sponge/sponge.go
+++ b/pkg/sponge/sponge.go
@@ -183,7 +183,7 @@ func importAll() {
 func importFromAPI(collections []string) {
 
 	finish := false
-	pageAfter := "1.399743732"
+	pageAfter := "1" //"1.399743732"
 	log.User(uuid, "sponge.importFromAPI", "### Reading data from API. \n")
 
 	api, ok := dbsource.(source.API)
@@ -195,7 +195,7 @@ func importFromAPI(collections []string) {
 	var err error
 	var data []map[string]interface{}
 
-	for !finish {
+	for true {
 		data, finish, pageAfter, err = api.GetAPIData(pageAfter)
 		if err != nil {
 			log.Error(uuid, "sponge.importFromAPI", err, "Getting data from API")
@@ -204,6 +204,10 @@ func importFromAPI(collections []string) {
 
 		if data != nil {
 			processAPI(collections, data)
+		}
+
+		if finish {
+			time.Sleep(5 * time.Minute) // sleep 5 minutes
 		}
 	}
 
@@ -332,7 +336,6 @@ func processAPI(collections []string, data []map[string]interface{}) {
 	totalDocuments := int64(len(data))
 
 	for _, row := range data {
-
 		// output benchmarking for each block of documents
 		if documents%blockSize == 0 && documents > 0 {
 
@@ -358,6 +361,7 @@ func processAPI(collections []string, data []map[string]interface{}) {
 				if options.reportOnFailedRecords {
 					report.Record(name, id, "Failing transform data", err)
 				}
+				break
 			}
 
 			// Usually newRows only will have a document but in the case that we have subcollections

--- a/pkg/sponge/sponge.go
+++ b/pkg/sponge/sponge.go
@@ -2,6 +2,7 @@
 package sponge
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -20,7 +21,20 @@ const (
 var (
 	dbsource source.Sourcer
 	uuid     string
+	options  Options
 )
+
+// Options will hold all the options that came from flags
+type Options struct {
+	limit                 int
+	offset                int
+	orderby               string
+	query                 string
+	types                 string
+	importonlyfailed      bool
+	reportOnFailedRecords bool
+	reportdbfile          string
+}
 
 // Init initialize the packages that are going to be used by sponge
 func Init(u string) error {
@@ -46,27 +60,45 @@ func Init(u string) error {
 	return err
 }
 
+// AddOptions adds flags to the sponge
+func AddOptions(limit int, offset int, orderby string, query string, types string, importonlyfailed bool, reportOnFailedRecords bool, reportdbfile string) {
+	options = Options{
+		limit:                 limit,
+		offset:                offset,
+		orderby:               orderby,
+		query:                 query,
+		types:                 types,
+		importonlyfailed:      importonlyfailed,
+		reportOnFailedRecords: reportOnFailedRecords,
+		reportdbfile:          reportdbfile,
+	}
+}
+
 // Import gets data, transform it and send it to pillar
-func Import(limit int, offset int, orderby string, query string, types string, importonlyfailed bool, reportOnFailedRecords bool, reportdbfile string) {
+func Import() {
 
-	if reportOnFailedRecords {
-		report.Init(uuid, reportdbfile)
+	// if there is a flag to start recording a report of failed records, then initialize it
+	if options.reportOnFailedRecords {
+		report.Init(uuid, options.reportdbfile)
 	}
 
-	// Connect to external source
-	log.User(uuid, "sponge.import", "### Connecting to external database...")
+	//import only failed reportOnFailedRecords
+	if options.importonlyfailed {
+		importOnlyFailedRecords() //dbsource, options)
+		return
+	}
 
-	if importonlyfailed { // import only what is in the report of failed imported records
-		importOnlyFailedRecords(dbsource, limit, offset, orderby, reportdbfile, reportOnFailedRecords)
-	} else { // import everything that is in the strategy
-		if types != "" {
-			for _, t := range strings.Split(types, ",") {
-				importType(dbsource, limit, offset, orderby, query, strings.Trim(t, " "), reportOnFailedRecords) // removes any extra space
-			}
-		} else {
-			importAll(dbsource, limit, offset, orderby, reportOnFailedRecords)
+	// import only the collections from the options
+	if options.types != "" {
+		for _, t := range strings.Split(options.types, ",") {
+			importType(strings.Trim(t, " ")) //dbsource, limit, offset, orderby, query, strings.Trim(t, " "), reportOnFailedRecords) // removes any extra space
 		}
+		return
 	}
+
+	// this is the func we are going to be running in daemon mode
+	importAll()
+
 }
 
 // CreateIndex will read the strategy file and create index that are mentioned there for each collection
@@ -92,13 +124,15 @@ func CreateIndex(collection string) {
 	coral.CreateIndex(collection)
 }
 
+//************ Not exported functions ************//
+
 // Import gets data from report on failed import, transform it and send it to pillar
-func importOnlyFailedRecords(dbsource source.Sourcer, limit int, offset int, orderby string, thisStrategy string, reportOnFailedRecords bool) {
+func importOnlyFailedRecords() { //dbsource source.Sourcer, limit int, offset int, orderby string, thisStrategy string, reportOnFailedRecords bool) {
 
 	log.User(uuid, "sponge.importOnlyFailedRecords", "### Reading file of data to import.")
 
 	// get the data that needs to be imported
-	tables, err := report.ReadReport(thisStrategy) //map[model]map[id]interface{}
+	tables, err := report.ReadReport(options.reportdbfile) //map[model]map[id]interface{}
 	if err != nil {
 		log.Error(uuid, "sponge.importOnlyFailedRecords", err, "Getting the rows that will be imported")
 	}
@@ -110,73 +144,115 @@ func importOnlyFailedRecords(dbsource source.Sourcer, limit int, offset int, ord
 		if len(ids) < 1 { // only one ID
 			// Get the data
 			log.User(uuid, "sponge.importOnlyFailedRecords", "### Reading data for table '%s'. \n", table)
-			data, err = dbsource.GetData(table, offset, limit, orderby, "")
+			data, _, err = dbsource.GetData(table, options.offset, options.limit, options.orderby, "")
 		} else {
 			log.User(uuid, "sponge.importOnlyFailedRecords", "### Reading data for table '%s', quering '%s'. \n", table, ids)
-			data, err = dbsource.GetQueryData(table, offset, limit, orderby, ids)
+			data, err = dbsource.GetQueryData(table, options.offset, options.limit, options.orderby, ids)
 		}
-		if err != nil && reportOnFailedRecords {
+		if err != nil && options.reportOnFailedRecords {
 			report.Record(table, ids, "Failing getting data", err)
 		}
 
 		// transform and get data into pillar
-		process(table, data, reportOnFailedRecords)
+		process(table, data)
 	}
 }
 
 // Import gets ALL data, transform it and send it to pillar
-func importAll(dbsource source.Sourcer, limit int, offset int, orderby string, reportOnFailedRecords bool) {
+func importAll() {
+	//dbsource source.Sourcer, limit int, offset int, orderby string, reportOnFailedRecords bool) {
 
 	log.User(uuid, "sponge.importAll", "### Reading tables to import from strategy file.")
 
-	//Get All the tables's names that we have in the strategy json file
-	tables, err := dbsource.GetTables()
+	//Get all the collections's names that we have in the strategy json file
+	collections, err := source.GetEntities()
 	if err != nil {
-		log.Error(uuid, "sponge.importAll", err, "Get external tables")
+		log.Error(uuid, "sponge.importAll", err, "Get collections's names.")
 		return
 	}
-	for _, modelName := range tables {
 
-		// Get the data
-		log.User(uuid, "sponge.importAll", "### Reading data from table '%s'. \n", modelName)
+	if dbsource.IsAPI() {
+		importFromAPI(collections)
+		return
+	}
 
-		data, err := dbsource.GetData(modelName, offset, limit, orderby, "")
+	importFromDB(collections)
+
+}
+
+func importFromAPI(collections []string) {
+
+	finish := false
+	pageAfter := "1.399743732"
+	log.User(uuid, "sponge.importFromAPI", "### Reading data from API. \n")
+
+	api, ok := dbsource.(source.API)
+	if !ok {
+		err := fmt.Errorf("Error asserting sourcer into source.API.")
+		log.Error(uuid, "sponge.importFromAPI", err, "Asserting type for source.API")
+	}
+
+	var err error
+	var data []map[string]interface{}
+
+	for !finish {
+		data, finish, pageAfter, err = api.GetAPIData(pageAfter)
 		if err != nil {
-			log.Error(uuid, "sponge.importAll", err, "Get external data for table %s.", modelName)
+			log.Error(uuid, "sponge.importFromAPI", err, "Getting data from API")
+			return
+		}
+
+		if data != nil {
+			processAPI(collections, data)
+		}
+	}
+
+}
+
+func importFromDB(collections []string) {
+	// var data []map[string]interface{}
+
+	for _, name := range collections { // Reads through all the collections whose transformations are in the strategy configuration file
+		// Get the data
+		log.User(uuid, "sponge.importAll", "### Reading data for collection '%s'. \n", name)
+
+		data, _, err := dbsource.GetData(name, options.offset, options.limit, options.orderby, "")
+		if err != nil {
+			log.Error(uuid, "sponge.importAll", err, "Get external data for collection %s.", name)
 			//RECORD to report about failing modelName
-			if reportOnFailedRecords {
-				report.Record(modelName, "", "Failing to get data.", err)
+			if options.reportOnFailedRecords {
+				report.Record(name, "", "Failing to get data.", err)
 			}
 			continue
 		}
-
-		//transform and send to pillar
-		process(modelName, data, reportOnFailedRecords)
+		//transform and send to pillar the data
+		process(name, data)
 	}
 }
 
 // ImportType gets ony data related to table, transform it and send it to pillar
-func importType(dbsource source.Sourcer, limit int, offset int, orderby string, query string, modelName string, reportOnFailedRecords bool) {
+func importType(name string) { //dbsource source.Sourcer, limit int, offset int, orderby string, query string, modelName string, reportOnFailedRecords bool) {
 
 	// Get the data
-	log.User(uuid, "sponge.importTable", "### Reading data from table '%s'.", modelName)
+	log.User(uuid, "sponge.importTable", "### Reading data from table '%s'.", name)
 
-	data, err := dbsource.GetData(modelName, offset, limit, orderby, query)
+	data, _, err := dbsource.GetData(name, options.offset, options.limit, options.orderby, options.query)
 	if err != nil {
-		log.Error(uuid, "sponge.importAll", err, "Get external data for table %s.", modelName)
+		log.Error(uuid, "sponge.importAll", err, "Get external data for table %s.", name)
 		//RECORD to report about failing modelName
-		if reportOnFailedRecords {
-			report.Record(modelName, "", "Failing to get data", err)
+		if options.reportOnFailedRecords {
+			report.Record(name, "", "Failing to get data", err)
 		}
 		return
 	}
 
 	// Transform and send to pillar
-	process(modelName, data, reportOnFailedRecords)
+	process(name, data)
 
 }
 
-func process(modelName string, data []map[string]interface{}, reportOnFailedRecords bool) {
+func process(modelName string, data []map[string]interface{}) {
+
 	// Transform the data row by row
 	log.User(uuid, "sponge.process", "# Transforming data to the coral schema.\n")
 	log.User(uuid, "sponge.process", "# And importing %v documents.", len(data))
@@ -211,7 +287,7 @@ func process(modelName string, data []map[string]interface{}, reportOnFailedReco
 		if err != nil {
 			log.Error(uuid, "sponge.process", err, "Error when transforming the row %s.", row)
 			//RECORD to report about failing transformation
-			if reportOnFailedRecords {
+			if options.reportOnFailedRecords {
 				report.Record(modelName, id, "Failing transform data", err)
 			}
 		}
@@ -234,8 +310,70 @@ func process(modelName string, data []map[string]interface{}, reportOnFailedReco
 			if err != nil {
 				log.Error(uuid, "sponge.process", err, "Error when adding a row") // thae row %v to %s.", string(newRow), modelName)
 				//RECORD to report about failing adding row to coral db
-				if reportOnFailedRecords {
+				if options.reportOnFailedRecords {
 					report.Record(modelName, id, "Failing add row to coral", err)
+				}
+			}
+		}
+	}
+}
+
+func processAPI(collections []string, data []map[string]interface{}) {
+
+	// Transform the data row by row
+	log.User(uuid, "sponge.processAPI", "# Transforming data to the coral schema.\n")
+	log.User(uuid, "sponge.processAPI", "# And importing %v documents.", len(data))
+
+	// Initialize benchmarking for current table
+	start := time.Now()
+	blockStart := time.Now()
+	blockSize := int64(1000) // number of documents between each report
+	documents := int64(0)
+	totalDocuments := int64(len(data))
+
+	for _, row := range data {
+
+		// output benchmarking for each block of documents
+		if documents%blockSize == 0 && documents > 0 {
+
+			// calculate stats
+			percentComplete := float64(documents) / float64(totalDocuments) * float64(100)
+			msSinceStart := time.Since(start).Nanoseconds() / int64(1000000)
+			msSinceBlock := time.Since(blockStart).Nanoseconds() / int64(1000000)
+			timeRemaining := int64(float64(time.Since(start).Seconds()) / float64(percentComplete) * float64(100))
+
+			//log stats
+			log.User(uuid, "sponge.process", "%v%% (%v/%v imported) %vms, %vms avg - last %v in %vms, %vms avg -- est time remaining %vs\n", int64(percentComplete), documents, totalDocuments, msSinceStart, msSinceStart/documents, blockSize, msSinceBlock, msSinceBlock/blockSize, int64(timeRemaining))
+			blockStart = time.Now()
+
+		}
+		documents = documents + 1
+
+		for _, name := range collections { // over the same row I look at the different collections in the strategy file
+			// transform the row
+			id, newRows, err := fiddler.TransformRow(row, name)
+			if err != nil {
+				log.Error(uuid, "sponge.process", err, "Error when transforming the row %s.", row)
+				//RECORD to report about failing transformation
+				if options.reportOnFailedRecords {
+					report.Record(name, id, "Failing transform data", err)
+				}
+			}
+
+			// Usually newRows only will have a document but in the case that we have subcollections
+			// we may get more than one document from a transformation
+			for _, newRow := range newRows {
+
+				log.Dev(uuid, "sponge.process", "Transforming: %v into %v.", row, newRow)
+
+				// send the row to pillar
+				err = coral.AddRow(newRow, name)
+				if err != nil {
+					log.Error(uuid, "sponge.process", err, "Error when adding a row") // thae row %v to %s.", string(newRow), modelName)
+					//RECORD to report about failing adding row to coral db
+					if options.reportOnFailedRecords {
+						report.Record(name, id, "Failing add row to coral", err)
+					}
 				}
 			}
 		}

--- a/pkg/sponge/sponge_test.go
+++ b/pkg/sponge/sponge_test.go
@@ -31,7 +31,7 @@ func setup() {
 		return ll
 	}
 
-	log.Init(os.Stderr, logLevel, log.Ldefault)
+	log.Init(os.Stderr, logLevel )
 
 	// MOCK STRATEGY CONF
 	strategyConf := "../../tests/strategy_test.json"

--- a/pkg/sponge/sponge_test.go
+++ b/pkg/sponge/sponge_test.go
@@ -78,29 +78,9 @@ func TestProcess(t *testing.T) {
 	var data []map[string]interface{}
 	reportOnFailedRecords := false
 
-	process(modelName, data, reportOnFailedRecords)
+	AddOptions(999, 0, "", "", "", false, reportOnFailedRecords, "")
+
+	process(modelName, data)
 
 	// check data is sent to pillar with the right transformations
-
-}
-
-// Signature: func importAll(mysql source.Sourcer, limit int, offset int, orderby string) {
-func TestImportAll(t *testing.T) {
-
-}
-
-func TestImportFailedRecordsWholeTable(t *testing.T) {
-
-}
-
-func TestImportFailedRecordsOneRecord(t *testing.T) {
-
-}
-
-func TestImportFailedRecordsTwoRecords(t *testing.T) {
-
-}
-
-func TestImportFailedRecordsTwoRecordsSeveralTables(t *testing.T) {
-
 }

--- a/pkg/strategy/README.md
+++ b/pkg/strategy/README.md
@@ -18,11 +18,11 @@ It describes the foreign database source. Right now we have only "mysql" availab
 
 If your source have date time fields, we need to know how to parse them. You should write the representation of 2006 Mon Jan 2 15:04:05 in the desired format. More more info read [pkg-constants](https://golang.org/pkg/time/#pkg-constants)
 
-### Tables
+### Entities
 
-It describe all the tables and its transformations.
+It describe all the different entities we have at the Coral database and how to do its transformations.
 
-#### Name of the table
+#### Name of the entity
 
 Example:
 ```
@@ -50,7 +50,7 @@ Example:
     {
       "foreign": "asseturl",
       "local": "url",
-      "relation": "Identity",
+      "relation": "Passthrough",
       "type": "int"
     },
     {
@@ -72,15 +72,15 @@ Example:
 
 ##### Foreign
 
-The name of the foreign table or collection.
+The name of the foreign entity.
 
 ##### Local
 
-The collection to where we are importing this table into.
+The collection to where we are importing this entity into.
 
 ##### Priority
 
-This is a number that specifies which table to import first. The first priority starts in Zero.
+This is a number that specifies which entity to import first. The first priority starts in Zero.
 
 ##### OrderBy
 
@@ -88,19 +88,19 @@ A default order by when quering the foreign source.
 
 ##### ID
 
-The identifier field for the foreign table. We use this field when we need to import only some records and not the whole table.
+The identifier field for the foreign entity. We use this field when we need to import only some records and not the whole entity.
 
 ##### Endpoint
 
-This is the endpoint in the coral system were we are going to push the data for this table into.
+This is the endpoint in the coral system were we are going to push the data into.
 
 ##### Fields
 
-All the fields for the table with the mapping
+All the fields that are being mapped.
 
 ###### Foreign
 
-The name of the field in the foreign table.
+The name of the field in the foreign entity.
 
 ###### Local
 
@@ -109,12 +109,12 @@ The name of the field in our local database.
 ###### Relation
 
 The relationship between the foreign field and the local one. We have this options:
-- Identity: when the value is the same
-- Source: when it needs to be added to our source struct for the local table (the original identifiers have to go into source)
+- Passthrough: when the value is the same
+- Source: when it needs to be added to our source struct for the local collection (the original identifiers have to go into source)
 - ParseTimeDate: when we need to parse the foreign value as date time.
 - Constant: when the local field should always be the same value. In this case we will have "foreign" blank and we will have other field called "value" with the value of the local field.
 - SubDocument: when the local field has an array of documents in one of the fields.
-- Status: when the field need to be translated based on the status map that is declared in that same strategy file for the table.
+- Status: when the field need to be translated based on the status map that is declared in that same strategy file for the entity.
 
 ###### Type
 
@@ -125,7 +125,7 @@ The type of the value we are converting.
 
 ## Credentials
 
-This has the credentials for the foreign database to pull data from.
+This has the credentials for the source database to pull data from. It could be an API or a Database (MySQL, PostgreSQL or MongoDB).
 
 ### adapter
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -23,17 +23,6 @@ var (
 func Init(u string) {
 
 	uuid = u
-
-	// logLevel := func() int {
-	// 	ll, err := cfg.Int("LOGGING_LEVEL")
-	// 	if err != nil {
-	// 		return log.USER
-	// 	}
-	// 	return ll
-	// }
-	//
-	// log.Init(os.Stderr, logLevel)
-
 	pillarURL = os.Getenv("PILLAR_URL")
 }
 
@@ -46,24 +35,24 @@ type Strategy struct {
 	Credentials Credentials // map[string][]Credential // String is "Databases" or "APIs" indicating which kind of credentials are those
 }
 
-// Map explains which tables or data we are getting from the source.
+// Map explains which entities or data we are getting from the source.
 type Map struct {
-	Foreign        string           `json:"foreign"`
-	DateTimeFormat string           `json:"datetimeformat"`
-	Tables         map[string]Table `json:"tables"`
+	Foreign        string            `json:"foreign"`
+	DateTimeFormat string            `json:"datetimeformat"`
+	Entities       map[string]Entity `json:"entities"`
 }
 
-// Table holds the struct on what is the external source's table name and fields
-type Table struct {
-	Foreign  string                   `json:"foreign"`
-	Local    string                   `json:"local"`
-	Priority int                      `json:"priority"`
-	OrderBy  string                   `json:"orderby"`
-	ID       string                   `json:"id"`
-	Index    []mgo.Index              `json:"index"`  //map[string]interface{} `json:"index"`
-	Fields   []map[string]interface{} `json:"fields"` // foreign (name in the foreign source), local (name in the local source), relation (relationship between each other), type (data type)
-	Status   map[string]string        `json:"status"`
-	Endpoint string                   `json:"endpoint"`
+// Entity holds the struct on what is the external source's entity name and fields
+type Entity struct {
+	Foreign        string                   `json:"foreign"`
+	Local          string                   `json:"local"`
+	Priority       int                      `json:"priority"`
+	OrderBy        string                   `json:"orderby"`
+	ID             string                   `json:"id"`
+	Index          []mgo.Index              `json:"index"`  //map[string]interface{} `json:"index"`
+	Fields         []map[string]interface{} `json:"fields"` // foreign (name in the foreign source), local (name in the local source), relation (relationship between each other), type (data type)
+	Status         map[string]string        `json:"status"`
+	PillarEndpoint string                   `json:"endpoint"`
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -72,8 +61,8 @@ type Table struct {
 
 // Credentials are all the credentials for external and internal data sources
 type Credentials struct {
-	Databases []CredentialDatabase
-	APIs      []CredentialAPI
+	Databases []CredentialDatabase `json:"databases"`
+	APIs      []CredentialAPI      `json:"apis"`
 }
 
 // Credential is the interface that CredentialDatabase and CredentialAPI will implement
@@ -104,8 +93,18 @@ func (c CredentialDatabase) GetType() string {
 
 // CredentialAPI has the information to connect to an external API source.
 type CredentialAPI struct {
-	Adapter   string            `json:"adapter"`
-	Endpoints map[string]string `json:"endpoints"`
+	AppKey     string `json:"appkey"`
+	Endpoint   string `json:"endpoint"`
+	Adapter    string `json:"adapter"`
+	Type       string `json:"type"`
+	Records    string `json:"records"`
+	UserAgent  string `json:"useragent"`
+	Attributes string `json:"attributes"`
+}
+
+// GetAppKey gets the app key to access the api
+func (c CredentialAPI) GetAppKey() string {
+	return c.AppKey
 }
 
 // GetAdapter returns the adapter
@@ -113,32 +112,29 @@ func (c CredentialAPI) GetAdapter() string {
 	return c.Adapter
 }
 
-// GetEndpoints returns all the endpoints
-func (c CredentialAPI) GetEndpoints() map[string]string {
-	return c.Endpoints
+// GetType returns the adapter
+func (c CredentialAPI) GetType() string {
+	return c.Type
 }
 
-// GetEndpoint gives the endpoint for that modelName
-func (c CredentialAPI) GetEndpoint(modelName string) (string, error) {
-	endpoints := c.GetEndpoints()
-	for k, e := range endpoints {
-		if k == modelName {
-			return e, nil
-		}
-	}
-
-	return "", fmt.Errorf("Error when trying to get endpoint %s.", modelName)
+// GetEndpoint returns all the endpoints
+func (c CredentialAPI) GetEndpoint() string {
+	return c.Endpoint
 }
 
-// GetAuthenticationEndpoint returns the authentication url
-func (c CredentialAPI) GetAuthenticationEndpoint() (string, error) {
-	for key, val := range c.Endpoints {
-		if key == "authentication" {
-			return val, nil
-		}
-	}
+// GetRecordsFieldName returns the name of the field that holds the records
+func (c CredentialAPI) GetRecordsFieldName() string {
+	return c.Records
+}
 
-	return "", fmt.Errorf("Error when trying to get endpoint authentication.")
+// GetUserAgent returns the name of the field that holds the user agent
+func (c CredentialAPI) GetUserAgent() string {
+	return c.UserAgent
+}
+
+// GetAttributes returns the attributes for the query
+func (c CredentialAPI) GetAttributes() string {
+	return c.Attributes
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -167,16 +163,24 @@ func New() (Strategy, error) {
 }
 
 // GetCredential returns the credentials for connection with the external source adapter a, type t
-func (s Strategy) GetCredential(a string, t string) (CredentialDatabase, error) {
-	var cred CredentialDatabase
+func (s Strategy) GetCredential(a string, t string) (Credential, error) {
+	var cred Credential
 	var err error
 
-	creda := s.Credentials.Databases
+	creda := s.Credentials
 
 	// look at the credentials related to local database (mongodb in our original example)
-	for i := 0; i < len(creda); i++ {
-		if creda[i].GetAdapter() == a && creda[i].GetType() == t {
-			cred = creda[i]
+	for i := 0; i < len(creda.Databases); i++ {
+		if creda.Databases[i].GetAdapter() == a && creda.Databases[i].GetType() == t {
+			cred = creda.Databases[i]
+			return cred, err
+		}
+	}
+
+	// look at the credentials related to local database (mongodb in our original example)
+	for i := 0; i < len(creda.APIs); i++ {
+		if creda.APIs[i].GetAdapter() == a && creda.APIs[i].GetType() == t {
+			cred = creda.APIs[i]
 			return cred, err
 		}
 	}
@@ -198,9 +202,9 @@ func (s Strategy) GetDefaultDateTimeFormat() string {
 }
 
 // GetDateTimeFormat returns the datetime format for this strategy
-func (s Strategy) GetDateTimeFormat(table string, field string) string {
+func (s Strategy) GetDateTimeFormat(entity string, field string) string {
 
-	for _, f := range s.Map.Tables[table].Fields {
+	for _, f := range s.Map.Entities[entity].Fields {
 		if f["local"] == field {
 			val, exists := f["datetimeformat"]
 			if exists {
@@ -211,13 +215,13 @@ func (s Strategy) GetDateTimeFormat(table string, field string) string {
 	return s.GetDefaultDateTimeFormat()
 }
 
-// GetTables returns a list of tables to be imported
-func (s Strategy) GetTables() map[string]Table {
-	return s.Map.Tables
+// GetEntities returns a list of the entities defined in the transformations file
+func (s Strategy) GetEntities() map[string]Entity {
+	return s.Map.Entities
 }
 
-// HasArrayField returns true if the table has fields that are type array and need to be loop through
-func (s Strategy) HasArrayField(t Table) bool {
+// HasArrayField returns true if the entity has fields that are type array and need to be loop through
+func (s Strategy) HasArrayField(t Entity) bool {
 	//Fields   []map[string]interface{}
 
 	for _, f := range t.Fields {
@@ -232,7 +236,7 @@ func (s Strategy) HasArrayField(t Table) bool {
 func (s Strategy) GetFieldsForSubDocument(model string, foreignfield string) []map[string]interface{} {
 	var fields []map[string]interface{}
 
-	for _, f := range s.Map.Tables[model].Fields { // search foreign field in []map[string]interface{}
+	for _, f := range s.Map.Entities[model].Fields { // search foreign field in []map[string]interface{}
 		if f["foreign"] == foreignfield {
 			fi := f["fields"].([]interface{})
 			// Convert the []interface into []map[string]interface{}
@@ -246,43 +250,43 @@ func (s Strategy) GetFieldsForSubDocument(model string, foreignfield string) []m
 	return fields
 }
 
-// GetTableForeignName returns the external source's table mapped to the coral model
-func (s Strategy) GetTableForeignName(coralName string) string {
-	return s.Map.Tables[coralName].Foreign
+// GetEntityForeignName returns the external source's entity mapped to the coral model
+func (s Strategy) GetEntityForeignName(coralName string) string {
+	return s.Map.Entities[coralName].Foreign
 }
 
-// GetTableForeignFields returns the external source's table fields mapped to the coral model
-func (s Strategy) GetTableForeignFields(coralName string) []map[string]interface{} {
-	return s.Map.Tables[coralName].Fields
+// GetEntityForeignFields returns the external source's entity fields mapped to the coral model
+func (s Strategy) GetEntityForeignFields(coralName string) []map[string]interface{} {
+	return s.Map.Entities[coralName].Fields
 }
 
-// GetOrderBy returns the order by field definied in the strategy
+// GetOrderBy returns the order by field definied in the transformations file
 func (s Strategy) GetOrderBy(coralName string) string {
-	return s.Map.Tables[coralName].OrderBy
+	return s.Map.Entities[coralName].OrderBy
 }
 
-// GetIndexBy returns the structure to use to create indexes for the coral table
-func (s Strategy) GetIndexBy(coralName string) []mgo.Index { //map[string]interface{} {
-	return s.Map.Tables[coralName].Index
+// GetIndexBy returns the structure to use to create indexes for the coral entity
+func (s Strategy) GetIndexBy(coralName string) []mgo.Index {
+	return s.Map.Entities[coralName].Index
 }
 
-// GetIDField returns the identifier for the table coralname setup in the strategy file
+// GetIDField returns the identifier for the entity coralname setup in the transformations file
 func (s Strategy) GetIDField(coralName string) string {
-	return s.Map.Tables[coralName].ID
+	return s.Map.Entities[coralName].ID
 }
 
 // GetStatus returns the mapping of the external status into the coral one
 func (s Strategy) GetStatus(coralName string, foreign string) string {
-	return s.Map.Tables[coralName].Status[foreign]
+	return s.Map.Entities[coralName].Status[foreign]
 }
 
 // GetPillarEndpoints return the endpoints configured in the strategy
 func (s Strategy) GetPillarEndpoints() map[string]string {
 	endpoints := map[string]string{}
 
-	tables := s.GetTables()
-	for _, table := range tables {
-		endpoints[table.Local] = pillarURL + table.Endpoint
+	entities := s.GetEntities()
+	for _, entity := range entities {
+		endpoints[entity.Local] = pillarURL + entity.PillarEndpoint
 	}
 
 	// adds CREATE_INDEX endpoints

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -104,8 +104,6 @@ func (c CredentialDatabase) GetType() string {
 
 // CredentialAPI has the information to connect to an external API source.
 type CredentialAPI struct {
-	Username  string            `json:"username"` // BasicAuth
-	Password  string            `json:"password"` // BasicAuth
 	Adapter   string            `json:"adapter"`
 	Endpoints map[string]string `json:"endpoints"`
 }

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -98,6 +98,7 @@ type CredentialAPI struct {
 	Adapter    string `json:"adapter"`
 	Type       string `json:"type"`
 	Records    string `json:"records"`
+	Pagination string `json:"pagination"`
 	UserAgent  string `json:"useragent"`
 	Attributes string `json:"attributes"`
 }
@@ -125,6 +126,11 @@ func (c CredentialAPI) GetEndpoint() string {
 // GetRecordsFieldName returns the name of the field that holds the records
 func (c CredentialAPI) GetRecordsFieldName() string {
 	return c.Records
+}
+
+// GetPaginationFieldName returns the name of the field where to look for pagination
+func (c CredentialAPI) GetPaginationFieldName() string {
+	return c.Pagination
 }
 
 // GetUserAgent returns the name of the field that holds the user agent

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -1,0 +1,73 @@
+package webservice
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/ardanlabs/kit/log"
+)
+
+const (
+	GET    string = "GET"
+	POST   string = "POST"
+	PUT    string = "PUT"
+	DELETE string = "DELETE"
+
+	retryTimes int = 3
+)
+
+//Response encapsulates a http response
+type Response struct {
+	Status     string
+	Header     http.Header
+	Body       string
+	StatusCode int
+}
+
+func DoRequest(uuid string, method string, urlStr string, payload io.Reader) (*Response, error) {
+
+	var err error
+	request, err := http.NewRequest(method, urlStr, payload)
+	if err != nil {
+		log.Error(uuid, "coral.doRequest", err, "New http request.")
+		return nil, err
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	var response *http.Response
+
+	// only retry if there is a network Errorf
+
+	// Retry retryTimes times if it fails to do the request
+	for i := 0; i < retryTimes; i++ {
+
+		response, err = client.Do(request)
+
+		if err != nil {
+			log.Error(uuid, "coral.doRequest", err, "Sending request number %d to Pillar.", i)
+		} else {
+
+			defer response.Body.Close()
+			resBody, _ := ioutil.ReadAll(response.Body)
+
+			if response.StatusCode != 200 {
+				err = fmt.Errorf("Not succesful status code: %s.", response.Status)
+				// wait and retry to do the request
+				time.Sleep(250 * time.Millisecond)
+			} else {
+				return &Response{
+					response.Status,
+					response.Header,
+					string(resBody),
+					response.StatusCode,
+				}, nil
+			}
+
+		}
+	}
+	return nil, err
+}

--- a/tests/response.json
+++ b/tests/response.json
@@ -1,0 +1,153 @@
+{
+  "children": {
+    "filter": "",
+    "itemsPerPage": 3,
+    "maxDepth": null,
+    "sortOrder": "chronological"
+  },
+  "entries": [
+    {
+      "actor": {
+        "_id": "http://washingtonpost.com/2fr0hQuh0mb1i38/PjD4X8goWI6YUHMFVlNQOUtKBgd/tT03sC7QkQ%3D%3D/",
+        "avatar": "http://akiajc2strzaac3fwsta.post-avatars.s3.amazonaws.com/0000012d-1049-4a57-4d62-0edc5b347cb2",
+        "id": "http://washingtonpost.com/2fr0hQuh0mb1i38/PjD4X8goWI6YUHMFVlNQOUtKBgd/tT03sC7QkQ%3D%3D/",
+        "links": [],
+        "markers": [],
+        "objectTypes": [
+          "http://activitystrea.ms/schema/1.0/person"
+        ],
+        "roles": [],
+        "status": "ModeratorApproved",
+        "title": "Duck504"
+      },
+      "hasMoreChildren": "false",
+      "id": "http://js-kit.com/activities/post/ac38d4b1-54cd-4008-b976-271d06504d52",
+      "object": {
+        "content": "I'm in my 60's.  I haven't gone for a checkup in a decade.  Why?  Because I am healthy.\n\nI monitor my weight and blood pressure.  I'm aware of my risk factors and monitor for signs of a problem there.  I know about how often and how long symptoms take to develop.  I know what aches and pains are normal and which are something new.\n\nLW - your parents may be doing a lot to monitor their health without telling you.  \n\nPS: I don't dislike doctors.  I just don't see a reason to go to them unless something might be wrong.",
+        "content_type": "html",
+        "context": [
+          {
+            "title": "",
+            "uri": "http://washingtonpost.com/lifestyle/style/carolyn-hax-stubborn-60-something-parent-refuses-to-see-a-doctor/2015/09/24/299ec776-5e2d-11e5-9757-e49273f05f65_story.html"
+          }
+        ],
+        "id": "http://washingtonpost.com/ECHO/item/ac38d4b1-54cd-4008-b976-271d06504d52",
+        "markers": [
+          "style"
+        ],
+        "objectTypes": [
+          "http://activitystrea.ms/schema/1.0/comment"
+        ],
+        "permalink": "",
+        "published": "2015-09-30T07:27:32Z",
+        "status": "Untouched",
+        "tags": []
+      },
+      "pageAfter": "1443598052.437",
+      "postedTime": "2015-09-30T07:27:32Z",
+      "provider": {
+        "icon": "http://cdn.echoenabled.com/images/echo.png",
+        "name": "echo",
+        "uri": "http://aboutecho.com/"
+      },
+      "source": {
+        "name": "washpost.com"
+      },
+      "targets": [
+        {
+          "conversationID": "http://washingtonpost.com/ECHO/item/ac38d4b1-54cd-4008-b976-271d06504d52",
+          "id": "http://washingtonpost.com/lifestyle/style/carolyn-hax-stubborn-60-something-parent-refuses-to-see-a-doctor/2015/09/24/299ec776-5e2d-11e5-9757-e49273f05f65_story.html"
+        }
+      ],
+      "updated": 1443598326.627,
+      "verbs": [
+        "http://activitystrea.ms/schema/1.0/post"
+      ]
+    },
+    {
+      "actor": {
+        "_id": "http://washingtonpost.com/VxReJMD1n22c6tRAx3osB/JkV59ZvvsMVMwGyOmCSUhoGeVxxhJF5A%3D%3D/",
+        "avatar": "https://wpidentity.s3.amazonaws.com/assets/images/avatar-default.png",
+        "id": "http://washingtonpost.com/VxReJMD1n22c6tRAx3osB/JkV59ZvvsMVMwGyOmCSUhoGeVxxhJF5A%3D%3D/",
+        "links": [],
+        "markers": [],
+        "objectTypes": [
+          "http://activitystrea.ms/schema/1.0/person"
+        ],
+        "roles": [],
+        "status": "ModeratorApproved",
+        "title": "SpunkyBug"
+      },
+      "hasMoreChildren": "false",
+      "id": "http://js-kit.com/activities/post/e00041c4-a5e1-4845-aac2-2e3cd4cd9a1d",
+      "object": {
+        "accumulators": {
+          "likesCount": 1
+        },
+        "content": "Here's some additional perspective: Even if you could get your parent to go to the doctor, who's to say they would follow the doctor's orders? My mom has an appointment with one of her long line of doctors every other month (at least). She loves going to the doctor. But the only thing she will do is take another pill. She will not exercise or eat right. I go with her on these appointments, and the doctors look at me like, why don't you make her eat better, why don't you make her exercise?  I finally had a calm talk with her, and I told her it was the last time I would ask her to get some exercise and eat healthier. She said she's 76, and she doesn't want to live to be a 100. I explained that she might not just drop dead one day, she might get really sick, and that could be very unpleasant, plus I will be the one who has to care for her. It didn't do any good. So, off to another doctor we go, and I am done begging.",
+        "content_type": "html",
+        "context": [
+          {
+            "title": "",
+            "uri": "http://washingtonpost.com/lifestyle/style/carolyn-hax-stubborn-60-something-parent-refuses-to-see-a-doctor/2015/09/24/299ec776-5e2d-11e5-9757-e49273f05f65_story.html"
+          }
+        ],
+        "id": "http://washingtonpost.com/ECHO/item/e00041c4-a5e1-4845-aac2-2e3cd4cd9a1d",
+        "likes": [
+          {
+            "actor": {
+              "avatar": "http://wpidpub.s3.amazonaws.com/0000014c-8185-268e-32e3-766c315a997a",
+              "id": "http://washingtonpost.com/lVT0b7rabmF9ndaJhWlxlewKrkvbT4tmVyJgOC1LXCRoGeVxxhJF5A%3D%3D/",
+              "links": [],
+              "objectTypes": [
+                "http://activitystrea.ms/schema/1.0/person"
+              ],
+              "title": "WoollyMammoth2"
+            },
+            "published": "2015-09-30T03:07:45Z"
+          }
+        ],
+        "markers": [
+          "style"
+        ],
+        "objectTypes": [
+          "http://activitystrea.ms/schema/1.0/comment"
+        ],
+        "permalink": "",
+        "published": "2015-09-28T17:37:40Z",
+        "status": "Untouched",
+        "tags": []
+      },
+      "pageAfter": "1443461860.966",
+      "postedTime": "2015-09-28T17:37:40Z",
+      "provider": {
+        "icon": "http://cdn.echoenabled.com/images/echo.png",
+        "name": "echo",
+        "uri": "http://aboutecho.com/"
+      },
+      "source": {
+        "name": "washpost.com"
+      },
+      "targets": [
+        {
+          "conversationID": "http://washingtonpost.com/ECHO/item/e00041c4-a5e1-4845-aac2-2e3cd4cd9a1d",
+          "id": "http://washingtonpost.com/lifestyle/style/carolyn-hax-stubborn-60-something-parent-refuses-to-see-a-doctor/2015/09/24/299ec776-5e2d-11e5-9757-e49273f05f65_story.html"
+        }
+      ],
+      "updated": 1443582465.146,
+      "verbs": [
+        "http://activitystrea.ms/schema/1.0/post"
+      ]
+    }
+    ],
+  "hasMoreChildren": "true",
+  "id": "https://comments-api-staging.ext.nile.works/v1/search?q=((scope: https:%2F%2Fwww.washingtonpost.com%2Flifestyle%2Fstyle%2Fcarolyn-hax-stubborn-60-something-parent-refuses-to-see-a-doctor%2F2015%2F09%2F24%2F299ec776-5e2d-11e5-9757-e49273f05f65_story.html source:washpost.com itemsPerPage: 100 sortOrder:reverseChronological ))&appkey=dev.washpost.com",
+  "itemsPerPage": 100,
+  "liveUpdatesTimeout": "15",
+  "nextPageAfter": "1443195024.171",
+  "nextSince": 1446786263.373,
+  "safeHTML": "aggressive",
+  "showFlags": "on",
+  "sortOrder": "reverseChronological",
+  "updated": 1460151053
+}

--- a/tests/response.json
+++ b/tests/response.json
@@ -43,7 +43,7 @@
         "status": "Untouched",
         "tags": []
       },
-      "pageAfter": "1443598052.437",
+      "pageAfter": "1443591222.437",
       "postedTime": "2015-09-30T07:27:32Z",
       "provider": {
         "icon": "http://cdn.echoenabled.com/images/echo.png",

--- a/tests/strategy_discourse_test.json
+++ b/tests/strategy_discourse_test.json
@@ -3,7 +3,7 @@
   "Map": {
     "Foreign": "postgresql",
     "DateTimeFormat": "2006-01-02 15:04:05",
-    "Tables": {
+    "Entities": {
       "assets": {
         "Foreign": "posts",
         "Local": "assets",

--- a/tests/strategy_nyt_test.json
+++ b/tests/strategy_nyt_test.json
@@ -3,10 +3,10 @@
   "Map": {
     "Foreign": "mysql",
     "DateTimeFormat": "2006-01-02 15:04:05",
-    "Tables": {
-      "asset": {
+    "Entities": {
+      "assets": {
         "Foreign": "crnr_asset",
-        "Local": "asset",
+        "Local": "assets",
         "Priority": 0,
         "OrderBy": "assetid",
         "ID": "assetid",
@@ -46,9 +46,9 @@
         ],
         "Endpoint": "/api/import/asset"
       },
-      "user": {
+      "users": {
         "Foreign": "crnr_comment",
-        "Local": "user",
+        "Local": "users",
         "Priority": 1,
         "OrderBy": "userid",
         "ID": "userid",
@@ -76,9 +76,9 @@
         ],
         "Endpoint": "/api/import/user"
       },
-      "comment": {
+      "comments": {
         "Foreign": "crnr_comment",
-        "Local": "comment",
+        "Local": "comments",
         "Priority": 2,
         "OrderBy": "createdate",
         "ID": "commentid",

--- a/tests/strategy_test.json
+++ b/tests/strategy_test.json
@@ -3,7 +3,7 @@
   "Map": {
     "Foreign": "mysql",
     "DateTimeFormat": "2006-01-02 15:04:05",
-    "Tables": {
+    "Entities": {
       "assets": {
         "Foreign": "crnr_asset",
         "Local": "assets",
@@ -44,7 +44,7 @@
             "type": "dateTime"
           }
         ],
-        "Endpoint": "/api/import/asset"
+        "endpoint": "/api/import/asset"
       },
       "users": {
         "Foreign": "crnr_comment",
@@ -74,7 +74,7 @@
             "type": "[]byte"
           }
         ],
-        "Endpoint": "/api/import/user"
+        "endpoint": "/api/import/user"
       },
       "comments": {
         "Foreign": "crnr_comment",

--- a/tests/strategy_wapo_test.json
+++ b/tests/strategy_wapo_test.json
@@ -3,158 +3,233 @@
   "Map": {
     "Foreign": "mongodb",
     "DateTimeFormat": "2006-01-02 15:04:05",
-    "Tables": {
-      "asset": {
-        "Foreign": "crnr_asset",
-        "Local": "asset",
+    "Entities": {
+      "users": {
+        "Foreign": "actors",
+        "Local": "users",
         "Priority": 0,
-        "OrderBy": "assetid",
-        "ID": "assetid",
+        "OrderBy": "_id",
+        "ID": "_id",
         "Index": [
           {
-            "name": "asset-url",
-            "keys": ["asseturl"],
-            "unique": true,
+            "name": "title",
+            "key": ["name"],
+            "unique": false,
             "dropdups": true
           }
         ],
         "Fields": [
           {
-            "foreign": "assetid",
+            "foreign": "_id",
             "local": "id",
             "relation": "Source",
-            "type": "int"
+            "type": "String"
           },
           {
-            "foreign": "asseturl",
-            "local": "url",
-            "relation": "Identity",
-            "type": "int"
-          },
-          {
-            "foreign": "updatedate",
-            "local": "date_updated",
-            "relation": "ParseTimeDate",
-            "type": "dateTime"
-          },
-          {
-            "foreign": "createdate",
-            "local": "date_created",
-            "relation": "ParseTimeDate",
-            "type": "dateTime"
-          }
-        ],
-        "Endpoint": "/api/import/asset"
-      },
-      "user": {
-        "Foreign": "crnr_comment",
-        "Local": "user",
-        "Priority": 1,
-        "OrderBy": "userid",
-        "ID": "userid",
-        "Index": [
-          {
-            "name": "user-name",
-            "keys": ["name"],
-            "unique": true,
-            "dropdups": true
-          }
-        ],
-        "Fields": [
-          {
-            "foreign": "userid",
-            "local": "id",
-            "relation": "Source",
-            "type": "int"
-          },
-          {
-            "foreign": "userdisplayname",
+            "foreign": "title",
             "local": "name",
             "relation": "Identity",
-            "type": "[]byte"
+            "type": "String"
+          },
+          {
+            "foreign": "status",
+            "local": "status",
+            "relation": "Identity",
+            "type": "String"
+          },
+          {
+            "foreign": "avatar",
+            "local": "avatar",
+            "relation": "Identity",
+            "type": "String"
           }
         ],
-        "Endpoint": "/api/import/user"
+        "endpoint": "/api/import/user"
       },
-      "comment": {
-        "Foreign": "crnr_comment",
-        "Local": "comment",
-        "Priority": 2,
-        "OrderBy": "createdate",
-        "ID": "commentid",
+      "comments": {
+        "Foreign": "comments",
+        "Local": "comments",
+        "Priority": 1,
+        "OrderBy": "postedTime",
+        "ID": "_id",
         "Index": [
           {
-            "name": "commentid",
-            "keys": ["commentid"],
-            "unique": true,
-            "dropdups": true
+            "name": "posted-time",
+            "key": ["date_created"],
+            "unique": false,
+            "dropdups": false
           }
         ],
         "Fields": [
           {
-            "foreign": "commentid",
+            "foreign": "_id",
             "local": "id",
             "relation": "Source",
-            "type": "int"
+            "type": "ObjectId"
           },
           {
-            "foreign": "commentbody",
+            "foreign": "object.content",
             "local": "body",
             "relation": "Identity",
-            "type": "[]byte"
+            "type": "String"
           },
           {
-            "foreign": "userid",
+            "foreign": "actor.id",
             "local": "user_id",
             "relation": "Source",
-            "type": "int"
+            "type": "String"
           },
           {
-            "foreign": "assetid",
+            "foreign": "object.context.0.uri",
             "local": "asset_id",
             "relation": "Source",
-            "type": "int"
+            "type": "String"
           },
           {
-            "foreign": "statusid",
+            "foreign": "object.status",
             "local": "status",
             "relation": "Identity",
             "type": "int"
           },
           {
-            "foreign": "parentid",
+            "foreign": "targets.0.id",
             "local": "parent_id",
             "relation": "Source",
             "type": "int"
           },
           {
-            "foreign": "createdate",
+            "foreign": "postedTime",
             "local": "date_created",
             "relation": "ParseTimeDate",
-            "type": "timedate"
+            "type": "timedate",
+            "datetimeformat": "2006-01-02 15:04:05 -0700 PST"
           },
           {
-            "foreign": "updatedate",
+            "foreign": "updated",
             "local": "date_updated",
             "relation": "ParseTimeDate",
             "type": "timedate",
-            "datetimeformat": "2006-01-02 15:04:05"
-          },
-          {
-            "foreign": "approvedate",
-            "local": "date_approved",
-            "relation": "ParseTimeDate",
-            "type": "timedate"
+            "datetimeformat": "2006-01-02 15:04:05 -0700 PST"
           }
         ],
-        "Endpoint": "/api/import/comment"
+        "endpoint": "/api/import/comment"
+      },
+      "actionsLikes": {
+        "Foreign": "comments",
+        "Local": "actions",
+        "Priority": 2,
+        "OrderBy": "",
+        "ID": "_id",
+        "Index": [
+          {
+            "name": "",
+            "key": [""],
+            "unique": false,
+            "dropdups": false
+          }
+        ],
+        "Fields": [
+          {
+            "foreign": "",
+            "value": "likes",
+            "local": "type",
+            "relation": "Constant",
+            "type": "String"
+          },
+          {
+            "foreign": "",
+            "value": "comments",
+            "local": "target",
+            "relation": "Constant",
+            "type": "String"
+          },
+          {
+            "foreign": "_id",
+            "local": "target_id",
+            "relation": "Source",
+            "type": "String"
+          },
+          {
+            "foreign": "object.likes",
+            "fields": [
+              {
+                "foreign": "published",
+                "local": "date",
+                "relation": "Identity"
+              },
+              {
+                "foreign": "actor.id",
+                "local" : "user_id",
+                "relation": "Source"
+              }
+            ],
+            "type": "Array",
+            "relation": "Loop"
+          }
+        ],
+        "endpoint": "/api/import/action"
+      },
+      "actionsFlags": {
+        "Foreign": "comments",
+        "Local": "actions",
+        "Priority": 3,
+        "OrderBy": "",
+        "ID": "_id",
+        "Index": [
+          {
+            "name": "",
+            "key": [""],
+            "unique": false,
+            "dropdups": false
+          }
+        ],
+        "Fields": [
+          {
+            "foreign": "",
+            "value": "flags",
+            "local": "type",
+            "relation": "Constant",
+            "type": "String"
+          },
+          {
+            "foreign": "",
+            "value": "comments",
+            "local": "target",
+            "relation": "Constant",
+            "type": "String"
+          },
+          {
+            "foreign": "_id",
+            "local": "target_id",
+            "relation": "Source",
+            "type": "String"
+          },
+          {
+            "foreign": "object.flags",
+            "fields": [
+              {
+                "foreign": "published",
+                "local": "date",
+                "relation": "Identity"
+              },
+              {
+                "foreign": "actor.id",
+                "local" : "user_id",
+                "relation": "Source"
+              }
+            ],
+            "type": "Array",
+            "relation": "Loop"
+          }
+        ],
+        "endpoint": "/api/import/action"
       }
     }
   },
   "Credentials": {
     "Databases": [
       {
-        "database": "coral_test",
+        "database": "original_wapo",
         "username": "gaba",
         "password": "gabita",
         "host": "127.0.0.1",


### PR DESCRIPTION
Issue #55.

Challenge:  To get data from APIs into fiddler to post to Pillar. 
Solution Options:

1) In the strategy file have the endpoint per collection. Pull data from that endpoint per each collection we need to get. Have a source implementation for APIs in general.
2) Still have the mapping in the strategy configuration file. But send the endpoints (to where pull data from) into a flag through the command line. In that case the import has to be done collection by collection. Have a source implementation for APIs in general.
3) Create a package that gets data from the WaPo API. And have a source implementation specifically for the WaPo (instead of generic for all the APIs). 