### PR TITLE
Make the Host and Port configureable for MySQL

### DIFF
--- a/pkg/source/mysql.go
+++ b/pkg/source/mysql.go
@@ -156,7 +156,7 @@ func connectionMySQL() string {
 		log.Error(uuid, "mysql.connectionMySQL", err, "Asserting Type CredentialDatabase")
 		return ""
 	}
-	return fmt.Sprintf("%s:%s@/%s", credentialD.Username, credentialD.Password, credentialD.Database)
+	return fmt.Sprintf("%s:%s@(%s:%s)/%s", credentialD.Username, credentialD.Password, credentialD.Host, credentialD.Port, credentialD.Database)
 }
 
 // Open gives back  DB


### PR DESCRIPTION
## What does this PR do?
This PR allows for users to configure the hostname and port for the MySQL driver (go-sql-driver).

Currently, using a `strategy.json` file with MySQL configurations will always default to `127.0.0.1:3306` for
any MySQL connections. 

[Go-SQL-Driver DSN Format](https://github.com/go-sql-driver/mysql#dsn-data-source-name)

## How do I test this PR?
Have a working `strategy.json` file with database configuration not pointing to 127.0.0.1:3306.
Even if it fails, it will display the attempted connection to the specified host.

## Notes
When the DSN contains empty parenthesis, it will still default to 127.0.0.1:3306. So the default behavior will not change.

@coralproject/backend

