### PR TITLE
Use the coral entity name for parameter to GetForeignEntity

### DIFF
--- a/pkg/sponge/sponge.go
+++ b/pkg/sponge/sponge.go
@@ -215,7 +215,7 @@ func importFromDB(collections []string) {
 		log.User(uuid, "sponge.importAll", "### Reading data to import from %s into collection '%s'. \n", foreignEntity, name)
 
 		// Get the data
-		data, err := dbsource.GetData(foreignEntity, &options) //options.offset, options.limit, options.orderby, "")
+		data, err := dbsource.GetData(name, &options) //options.offset, options.limit, options.orderby, "")
 		if err != nil {
 			log.Error(uuid, "sponge.importAll", err, "Get external data for collection %s.", name)
 			//RECORD to report about failing modelName


### PR DESCRIPTION
## What does this PR do?
This PR attempts to fix a bug where the incorrect parameter may be passed into `dbsource.GetData(name, options)`. 

Currently, the foreign entity name is being passed in whereas it seems like the coral name should be passed in. Within the GetData function, the foreign entity is then looked up.

The current behavior causes the foreign entity name to be passed in, no entry should be present for that key in the Entities map and thus an empty string is returned. This causes the SQL statements to not be properly constructed leading to a syntax error.

## Code Walkthrough
Foreign entity passed in [here](https://github.com/coralproject/sponge/blob/master/pkg/sponge/sponge.go#L237-L241). We then attempt to lookup the Foreign Entity using the Foreign Entity [here](https://github.com/coralproject/sponge/blob/master/pkg/source/mysql.go#L33-L34).
It is implied that the coral name should be passed in [here](https://github.com/coralproject/sponge/blob/master/pkg/strategy/strategy.go#L299-L302).
This is based off the mapping of the JSON strategy file format [here](https://github.com/coralproject/sponge/blob/master/data/strategy_mysql.json.example#L6-L8).

## How do I test this PR?
Using a properly configured `strategy.json` file, attempt to use a MySQL datasource to import from your tables.

@coralproject/backend

