### PR TITLE
Provide an entrypoint for the Sponge binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ RUN cd /go/src/github.com/coralproject/sponge/cmd/sponge && go install
 
 ENV PATH /go/bin:$PATH
 
-# Run the app
-CMD ["sponge", "import"]
+ENTRYPOINT ["sponge"]
+
+# Run the app with the default import command.
+CMD ["import"]


### PR DESCRIPTION
## What does this PR do?

Makes the entrypoint for the dockerized sponge container the `sponge` binary and the default parameter to be the import command.

It maintains backwards compatibility with previous documentation that indicates running 
`docker run --env-file env.list -d sponge` will run the equivalent of `./sponge import`.

Exposes the rest of the binary's functionality by allowing users to pass other parameters besides import.

This PR allows us to run more than `sponge import` using the same command.

## How do I test this PR?
Build the docker image:
`docker build -t "sponge:latest" -f Dockerfile ./`

Run it to see the default behavior has not changed:
`docker run --env-file env.list -d sponge`

Now run it using different any of the allowed parameters:
`docker run --env-file env.list -d sponge import --limit=1000 --offset=20`
`docker run --env-file env.list -d sponge -h`

@coralproject/backend
